### PR TITLE
Feat narrow notes

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -12,3 +12,5 @@ api
 # interlinks
 _inv
 objects.json
+_sidebar.yml
+_extensions

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+objects.json
+_extensions
+_inv
+_sidebar.yml

--- a/quartodoc/renderers.py
+++ b/quartodoc/renderers.py
@@ -1,91 +1,14 @@
+import quartodoc.ast as qast
 import re
 
-from enum import Enum
 from griffe.docstrings import dataclasses as ds
 from griffe import dataclasses as dc
-from dataclasses import dataclass
 from tabulate import tabulate
 from plum import dispatch
 from typing import Tuple, Union
 
 
-# Docstring rendering =========================================================
-
 # utils -----------------------------------------------------------------------
-# these largely re-format the output of griffe
-
-
-def tuple_to_data(el: "tuple[ds.DocstringSectionKind, str]"):
-    """Re-format funky tuple setup in example section to be a class."""
-    assert len(el) == 2
-
-    kind, value = el
-    if kind.value == "examples":
-        return ExampleCode(value)
-    elif kind.value == "text":
-        return ExampleText(value)
-
-    raise ValueError(f"Unsupported first element in tuple: {kind}")
-
-
-def docstring_section_narrow(el: ds.DocstringSection) -> ds.DocstringSection:
-    # attempt to narrow down text sections
-    to_narrow = [
-        DocstringSectionSeeAlso,
-        DocstringSectionNotes,
-        DocstringSectionWarnings,
-    ]
-    prefix = "See Also\n---"
-
-    if isinstance(el, ds.DocstringSectionText):
-        for cls in to_narrow:
-            prefix = cls.kind.value.title() + "\n---"
-            if el.value.lstrip("\n").startswith(prefix):
-
-                stripped = el.value.replace(prefix, "", 1).lstrip("-\n")
-                return cls(stripped, el.title)
-
-    return el
-
-
-class DocstringSectionKindPatched(Enum):
-    see_also = "see also"
-    notes = "notes"
-    warnings = "warnings"
-
-
-class DocstringSectionSeeAlso(ds.DocstringSection):
-    kind = DocstringSectionKindPatched.see_also
-
-    def __init__(self, value: str, title: "str | None"):
-        self.value = value
-        super().__init__(title)
-
-
-class DocstringSectionNotes(ds.DocstringSection):
-    kind = DocstringSectionKindPatched.notes
-
-    def __init__(self, value: str, title: "str | None"):
-        self.value = value
-        super().__init__(title)
-
-
-class DocstringSectionWarnings(ds.DocstringSection):
-    kind = DocstringSectionKindPatched.warnings
-
-    def __init__(self, value: str, title: "str | None"):
-        self.value = value
-        super().__init__(title)
-
-
-@dataclass
-class ExampleCode:
-    value: str
-
-
-@dataclass
-class ExampleText:
-    value: str
 
 
 def escape(val: str):
@@ -258,7 +181,7 @@ class MdRenderer(Renderer):
             pass
         else:
             for section in el.docstring.parsed:
-                new_el = docstring_section_narrow(section)
+                new_el = qast.transform(section)
                 title = new_el.kind.value
                 body = self.render(new_el)
 
@@ -309,7 +232,7 @@ class MdRenderer(Renderer):
     # or a section with a header not included in the numpydoc standard
     @dispatch
     def render(self, el: ds.DocstringSectionText):
-        new_el = docstring_section_narrow(el)
+        new_el = qast.transform(el)
         if isinstance(new_el, ds.DocstringSectionText):
             # ensures we don't recurse forever
             return el.value
@@ -349,7 +272,7 @@ class MdRenderer(Renderer):
     # see also ----
 
     @dispatch
-    def render(self, el: DocstringSectionSeeAlso):
+    def render(self, el: qast.DocstringSectionSeeAlso):
         # TODO: attempt to parse See Also sections
         return convert_rst_link_to_md(el.value)
 
@@ -358,11 +281,11 @@ class MdRenderer(Renderer):
     @dispatch
     def render(self, el: ds.DocstringSectionExamples):
         # its value is a tuple: DocstringSectionKind["text" | "examples"], str
-        data = map(tuple_to_data, el.value)
+        data = map(qast.transform, el.value)
         return "\n\n".join(list(map(self.render, data)))
 
     @dispatch
-    def render(self, el: ExampleCode):
+    def render(self, el: qast.ExampleCode):
         return f"""```python
 {el.value}
 ```"""
@@ -384,7 +307,7 @@ class MdRenderer(Renderer):
     # unsupported parts ----
 
     @dispatch
-    def render(self, el: ExampleText):
+    def render(self, el: qast.ExampleText):
         return el.value
 
     @dispatch.multi(

--- a/quartodoc/renderers.py
+++ b/quartodoc/renderers.py
@@ -269,12 +269,24 @@ class MdRenderer(Renderer):
         annotation = self._render_annotation(el.annotation)
         return el.name, self.render(annotation), el.description
 
+    # warnings ----
+
+    @dispatch
+    def render(self, el: qast.DocstringSectionWarnings):
+        return el.value
+
     # see also ----
 
     @dispatch
     def render(self, el: qast.DocstringSectionSeeAlso):
         # TODO: attempt to parse See Also sections
         return convert_rst_link_to_md(el.value)
+
+    # notes ----
+
+    @dispatch
+    def render(self, el: qast.DocstringSectionNotes):
+        return el.value
 
     # examples ----
 
@@ -289,6 +301,10 @@ class MdRenderer(Renderer):
         return f"""```python
 {el.value}
 ```"""
+
+    @dispatch
+    def render(self, el: qast.ExampleText):
+        return el.value
 
     # returns ----
 
@@ -305,10 +321,6 @@ class MdRenderer(Renderer):
         return (annotation, el.description)
 
     # unsupported parts ----
-
-    @dispatch
-    def render(self, el: qast.ExampleText):
-        return el.value
 
     @dispatch.multi(
         (ds.DocstringAdmonition,),

--- a/quartodoc/renderers.py
+++ b/quartodoc/renderers.py
@@ -30,20 +30,48 @@ def tuple_to_data(el: "tuple[ds.DocstringSectionKind, str]"):
 
 def docstring_section_narrow(el: ds.DocstringSection) -> ds.DocstringSection:
     # attempt to narrow down text sections
+    to_narrow = [
+        DocstringSectionSeeAlso,
+        DocstringSectionNotes,
+        DocstringSectionWarnings,
+    ]
     prefix = "See Also\n---"
-    if isinstance(el, ds.DocstringSectionText) and el.value.startswith(prefix):
-        stripped = el.value.replace(prefix, "", 1).lstrip("-\n")
-        return DocstringSectionSeeAlso(stripped, el.title)
+
+    if isinstance(el, ds.DocstringSectionText):
+        for cls in to_narrow:
+            prefix = cls.kind.value.title() + "\n---"
+            if el.value.lstrip("\n").startswith(prefix):
+
+                stripped = el.value.replace(prefix, "", 1).lstrip("-\n")
+                return cls(stripped, el.title)
 
     return el
 
 
 class DocstringSectionKindPatched(Enum):
     see_also = "see also"
+    notes = "notes"
+    warnings = "warnings"
 
 
 class DocstringSectionSeeAlso(ds.DocstringSection):
     kind = DocstringSectionKindPatched.see_also
+
+    def __init__(self, value: str, title: "str | None"):
+        self.value = value
+        super().__init__(title)
+
+
+class DocstringSectionNotes(ds.DocstringSection):
+    kind = DocstringSectionKindPatched.notes
+
+    def __init__(self, value: str, title: "str | None"):
+        self.value = value
+        super().__init__(title)
+
+
+class DocstringSectionWarnings(ds.DocstringSection):
+    kind = DocstringSectionKindPatched.warnings
 
     def __init__(self, value: str, title: "str | None"):
         self.value = value

--- a/quartodoc/tests/test_ast.py
+++ b/quartodoc/tests/test_ast.py
@@ -1,9 +1,11 @@
 import quartodoc.ast as qast
-
 import pytest
+
 from griffe.docstrings import dataclasses as ds
 from griffe import dataclasses as dc
 from griffe.docstrings.parsers import parse_numpy
+
+from quartodoc import get_object
 
 
 @pytest.mark.parametrize(
@@ -59,3 +61,11 @@ def test_transform_docstring_section_clump():
 
     # what to do here? this should more reasonably be handled when transform
     # operates on the root.
+
+
+def test_preview_no_fail(capsys):
+    qast.preview(get_object("quartodoc", "get_object"))
+
+    res = capsys.readouterr()
+
+    assert "get_object" in res.out

--- a/quartodoc/tests/test_ast.py
+++ b/quartodoc/tests/test_ast.py
@@ -1,0 +1,61 @@
+import quartodoc.ast as qast
+
+import pytest
+from griffe.docstrings import dataclasses as ds
+from griffe import dataclasses as dc
+from griffe.docstrings.parsers import parse_numpy
+
+
+@pytest.mark.parametrize(
+    "el, body",
+    [
+        ("See Also\n---", ""),
+        ("See Also\n---\n", ""),
+        ("See Also\n--------", ""),
+        ("\n\nSee Also\n---\n", ""),
+        ("See Also\n---\nbody text", "body text"),
+        ("See Also\n---\nbody text", "body text"),
+    ],
+)
+def test_transform_docstring_section(el, body):
+    src = ds.DocstringSectionText(el, title=None)
+    res = qast._DocstringSectionPatched.transform(src)
+
+    assert isinstance(res, qast.DocstringSectionSeeAlso)
+    assert res.value == body
+
+
+@pytest.mark.parametrize(
+    "el, cls",
+    [
+        ("See Also\n---", qast.DocstringSectionSeeAlso),
+        ("Warnings\n---", qast.DocstringSectionWarnings),
+        ("Notes\n---", qast.DocstringSectionNotes),
+    ],
+)
+def test_transform_docstring_section_subtype(el, cls):
+    # using transform method ----
+    src = ds.DocstringSectionText(el, title=None)
+    res = qast._DocstringSectionPatched.transform(src)
+
+    assert isinstance(res, cls)
+
+    # using transform function ----
+    parsed = parse_numpy(dc.Docstring(el))
+    assert len(parsed) == 1
+
+    res2 = qast.transform(parsed[0])
+    assert isinstance(res2, cls)
+
+
+@pytest.mark.xfail(reason="TODO: sections get grouped into single element")
+def test_transform_docstring_section_clump():
+    docstring = "See Also---\n\nWarnings\n---\n\nNotes---\n\n"
+    parsed = parse_numpy(dc.Docstring(docstring))
+
+    assert len(parsed) == 1
+
+    # res = transform(parsed[0])
+
+    # what to do here? this should more reasonably be handled when transform
+    # operates on the root.


### PR DESCRIPTION
* Adds support for narrowing DocstringSectionText to specific classes for "Warnings", and "Notes" (see https://github.com/machow/quartodoc/issues/34#issuecomment-1421248993)
* Refactors transformation logic to live in the `quartodoc.ast` submodule
* Adds basic tests of narrowing.