### PR TITLE
feat: add dynamic option to get_object

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import yaml
 
@@ -70,6 +72,7 @@ def get_object(
     object_name: str,
     parser: str = "numpy",
     load_aliases=True,
+    dynamic=False,
     modules_collection: "None | ModulesCollection" = None,
 ) -> dc.Object:
     """Fetch a griffe object.
@@ -84,6 +87,9 @@ def get_object(
         A docstring parser to use.
     load_aliases: bool
         For aliases that were imported from other modules, should we load that module?
+    dynamic: bool
+        Whether to dynamically import object. Useful if docstring is not hard-coded,
+        but was set on object by running python code.
     modules_collection: optional
         A griffe [](`~griffe.collections.ModulesCollection`), used to hold loaded modules.
 
@@ -125,7 +131,35 @@ def get_object(
         if target_mod != module:
             griffe.load_module(target_mod)
 
+    if dynamic:
+        obj = f_data.target if isinstance(f_data, Alias) else f_data
+        replace_docstring(obj)
+
     return f_data
+
+
+def replace_docstring(obj: dc.Object | dc.Alias, f):
+    import importlib
+
+    mod = importlib.import_module(obj.module.canonical_path)
+
+    # TODO: handle top-level modules. this assumes it's the child of a module.
+    f = getattr(mod, obj.name)
+
+    old = obj.docstring
+    new = dc.Docstring(
+        value=f.__doc__,
+        lineno=old.lineno,
+        endlineno=old.endlineno,
+        parent=old.parent,
+        parser=old.parser,
+        parser_options=old.parser_options,
+    )
+
+    if isinstance(obj, dc.Alias):
+        obj.target.docstring = new
+    else:
+        obj.docstring = new
 
 
 # pkgdown =====================================================================

--- a/quartodoc/tests/example_dynamic.py
+++ b/quartodoc/tests/example_dynamic.py
@@ -1,0 +1,11 @@
+NOTE = "Notes\n----\nI am a note"
+
+
+def f(a, b, c):
+    """Return something
+
+    {note}
+    """
+
+
+f.__doc__ = f.__doc__.format(note=NOTE)

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -17,3 +17,18 @@ def test_renderer_render():
 
     renderer = MdRenderer()
     assert isinstance(renderer.render(f_obj), str)
+
+
+def test_replace_docstring():
+    from quartodoc.autosummary import get_object, replace_docstring
+    from quartodoc.tests.example_dynamic import f
+
+    obj = get_object("quartodoc", "tests.example_dynamic.f")
+    old = obj.docstring
+
+    replace_docstring(obj, f)
+    assert obj.docstring is not old
+
+    # just check the end of the piece dynamically added to docstring, since
+    # griffe strips the left padding from docstrings.
+    assert obj.docstring.value.endswith("I am a note")


### PR DESCRIPTION
Addresses https://github.com/machow/quartodoc/issues/54, https://github.com/machow/quartodoc/issues/3, by adding a dynamic flag to get_object -- which allows you to dynamically load the exact docstring for a function.