### PR TITLE
use render instead of to_md in README

### DIFF
--- a/README.qmd
+++ b/README.qmd
@@ -44,7 +44,7 @@ f_obj = get_function("quartodoc", "get_function")
 # render ---
 renderer = MdRenderer(header_level = 1)
 print(
-    renderer.to_md(f_obj)
+    renderer.render(f_obj)
 )
 ```
 
@@ -100,7 +100,7 @@ quartodoc consists of two pieces:
 * **collection**: using the library [griffe](https://github.com/mkdocstrings/griffe) to statically
 collect information about functions and classes in a program.
 * **docstring parsing**: also handled by griffe, which breaks it into a tree structure.
-* **docstring rendering**: use plum-dispatch on methods like MdRenderer.to_md to decide
+* **docstring rendering**: use plum-dispatch on methods like MdRenderer.render to decide
   how to visit and render each piece of the tree (e.g. the examples section, a parameter, etc..).
 
 Here is a quick example of how you can grab a function from griffe and walk through it.
@@ -132,7 +132,7 @@ from quartodoc import MdRenderer
 renderer = MdRenderer()
 
 print(
-    renderer.to_md(docstring[1])
+    renderer.render(docstring[1])
 )
 ```
 


### PR DESCRIPTION
Looks like this was missed in #36.