### PR TITLE
fix: patched docstrings missing their contents

### DIFF
--- a/quartodoc/ast.py
+++ b/quartodoc/ast.py
@@ -39,8 +39,8 @@ class _DocstringSectionPatched(ds.DocstringSection):
     _registry: "dict[Enum, _DocstringSectionPatched]" = {}
 
     def __init__(self, value: str, title: "str | None" = None):
-        self.value = value
         super().__init__(title)
+        self.value = value
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
This PR fixes a recent issue, where patched docstring sections were missing their contents. For example, quartodoc adds in a custom DocstringNotesSection, whose `.value` was None in a vetiver docs build.

I think this is likely a regression, since there are already tests to cover this case. (I was able to fix the vetiver build with this change).