### PR TITLE
ux: log when an api page is written

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -515,6 +515,7 @@ class Builder:
                 or (not html_path.exists())
                 or (html_path.read_text() != rendered)
             ):
+                _log.info(f"Writing {page.path}")
                 html_path.write_text(rendered)
 
     # inventory ----

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ zipsafe = False
 
 python_requires = >=3.9
 install_requires =
-    griffe>=0.25
+    griffe>=0.25,<0.27
     plum-dispatch<2.0.0;python_version<'3.10'
     plum-dispatch;python_version>='3.10'
     sphobjinv

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ zipsafe = False
 
 python_requires = >=3.9
 install_requires =
-    griffe>=0.25,<0.27
+    griffe==0.25
     plum-dispatch<2.0.0;python_version<'3.10'
     plum-dispatch;python_version>='3.10'
     sphobjinv


### PR DESCRIPTION
This PR adds a log message from the Builder, when a page is written. This means that when people run `python -m quartodoc build --verbose`, they get feedback on what pages are re-written.

This is important because for sites with hundreds of pages, re-writing pages means waiting for quarto to re-render them.