### PR TITLE
fix: always render *args and **kwargs in signature

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -311,7 +311,7 @@ class MdRenderer(Renderer):
         elif has_default:
             res = f"{glob}{el.name}={el.default}"
         else:
-            res = el.name
+            res = f"{glob}{el.name}"
 
         return sanitize(res)
 

--- a/quartodoc/tests/example_signature.py
+++ b/quartodoc/tests/example_signature.py
@@ -1,0 +1,8 @@
+def no_annotations(a, b=1, *args, c, d=2, **kwargs):
+    """A function with a signature"""
+
+
+def yes_annotations(
+    a: int, b: int = 1, *args: list[str], c: int, d: int, **kwargs: dict[str, str]
+):
+    """A function with a signature"""

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -1,0 +1,30 @@
+import pytest
+
+from quartodoc.renderers import MdRenderer
+from quartodoc import get_object
+
+# TODO: tests in test_basic.py also use the renderer, so we should move them here.
+
+
+@pytest.fixture
+def renderer():
+    return MdRenderer()
+
+
+def test_render_param_kwargs(renderer):
+    f = get_object("quartodoc.tests.example_signature.no_annotations")
+    res = renderer.render(f.parameters)
+
+    assert res == "a, b=1, *args, *, c, d=2, **kwargs"
+
+
+def test_render_param_kwargs_annotated():
+    renderer = MdRenderer(show_signature_annotations=True)
+    f = get_object("quartodoc.tests.example_signature.yes_annotations")
+
+    res = renderer.render(f.parameters)
+
+    assert (
+        res
+        == "a: int, b: int = 1, *args: list\\[str\\], *, c: int, d: int, **kwargs: dict\\[str, str\\]"
+    )


### PR DESCRIPTION
This PR addresses #91 and #93 by ensuring the renderer always renders a signature with `*` or `**` for `*args` and `**kwargs`, respectively. Currently, it erroneously omits this if the renderer does not have show_signature_annotations set to True.