### PR TITLE
feat: add cli entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ examples/%/_site: examples/%/_quarto.yml
 	cd examples/$* \
 		&& quarto add --no-prompt ../.. \
 		&& quarto add --no-prompt quarto-ext/shinylive
-	cd examples/$* && python -m quartodoc build _quarto.yml --verbose
-	cd examples/$* && python -m quartodoc interlinks
+	cd examples/$* && quartodoc build _quarto.yml --verbose
+	cd examples/$* && quartodoc interlinks
 	quarto render $(dir $<)
 
 docs/examples/%: examples/%/_site
@@ -17,8 +17,8 @@ docs-build-examples: docs/examples/single-page docs/examples/pkgdown docs/exampl
 
 docs-build: docs-build-examples
 	cd docs && quarto add --no-prompt ..
-	cd docs && python -m quartodoc build
-	cd docs && python -m quartodoc interlinks
+	cd docs && quartodoc build
+	cd docs && quartodoc interlinks
 	quarto render docs
 
 requirements-dev.txt:

--- a/quartodoc/renderers/base.py
+++ b/quartodoc/renderers/base.py
@@ -74,10 +74,22 @@ class Renderer:
             raise TypeError(type(cfg))
 
         if style.endswith(".py"):
+            import os
+            import sys
             import importlib
 
-            mod = importlib.import_module(style.rsplit(".", 1)[0])
-            return mod.Renderer(**cfg)
+            # temporarily add the current directory to sys path and import
+            # this ensures that even if we're executing the quartodoc cli,
+            # we can import a custom _renderer.py file.
+            # it probably isn't ideal, but seems like a more convenient
+            # option than requiring users to register entrypoints.
+            sys.path.append(os.getcwd())
+
+            try:
+                mod = importlib.import_module(style.rsplit(".", 1)[0])
+                return mod.Renderer(**cfg)
+            finally:
+                sys.path.pop()
 
         subclass = cls._registry[style]
         return subclass(**cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,10 @@ dev =
     jupyterlab
     jupytext
 
+[options.entry_points]
+console_scripts =
+    quartodoc = quartodoc.__main__:cli
+
 
 [project.scripts]
 quartodoc = "quartodoc.cli:main"


### PR DESCRIPTION
Addresses #106, by creating a command line interface for quartodoc, e.g., from the shell:

```
quartodoc --help
quartodoc build --verbose
```

It uses the same mechanism as the `python -m quartodoc` approach, so behaviors should be identical. I should note that the `python -m ` approach sets the sys path to be the cwd, while the CLI approach sets it to be the bin directory (or something like that)