### PR TITLE
fix: better support for rendering /, and * in signatures

### DIFF
--- a/quartodoc/tests/example_signature.py
+++ b/quartodoc/tests/example_signature.py
@@ -6,3 +6,19 @@ def yes_annotations(
     a: int, b: int = 1, *args: list[str], c: int, d: int, **kwargs: dict[str, str]
 ):
     """A function with a signature"""
+
+
+def pos_only(x, /, a, b=2):
+    ...
+
+
+def kw_only(x, *, a, b=2):
+    ...
+
+
+def early_args(x, *args, a, b=2, **kwargs):
+    ...
+
+
+def late_args(x, a, b=2, *args, **kwargs):
+    ...

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -15,7 +15,7 @@ def test_render_param_kwargs(renderer):
     f = get_object("quartodoc.tests.example_signature.no_annotations")
     res = renderer.render(f.parameters)
 
-    assert res == "a, b=1, *args, *, c, d=2, **kwargs"
+    assert res == "a, b=1, *args, c, d=2, **kwargs"
 
 
 def test_render_param_kwargs_annotated():
@@ -26,5 +26,21 @@ def test_render_param_kwargs_annotated():
 
     assert (
         res
-        == "a: int, b: int = 1, *args: list\\[str\\], *, c: int, d: int, **kwargs: dict\\[str, str\\]"
+        == "a: int, b: int = 1, *args: list\\[str\\], c: int, d: int, **kwargs: dict\\[str, str\\]"
     )
+
+
+@pytest.mark.parametrize(
+    "src, dst",
+    [
+        ("example_signature.pos_only", "x, /, a, b=2"),
+        ("example_signature.kw_only", "x, *, a, b=2"),
+        ("example_signature.early_args", "x, *args, a, b=2, **kwargs"),
+        ("example_signature.late_args", "x, a, b=2, *args, **kwargs"),
+    ],
+)
+def test_render_param_kwonly(src, dst, renderer):
+    f = get_object("quartodoc.tests", src)
+
+    res = renderer.render(f.parameters)
+    assert res == dst


### PR DESCRIPTION
Addresses #117, 

* ensures a lone `*, ` is *not* added to a signature when a varargs arg comes before a kw only arg
  - e.g. `def f(a, *args, b)`
  - e.g. `def f(a, *, b)`
* correctly render position only args (e.g. `def f(a, /): ...`)
* add tests of 4 common signature configurations