### PR TITLE
docs: fix misnamed page references

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -58,9 +58,8 @@ website:
           contents:
             - get-started/dev-big-picture.qmd
             - get-started/dev-prepare.qmd
-            - get-started/docstrings.qmd
-            - get-started/renderers.qmd
-            - get-started/dev-dataclasses.qmd
+            - get-started/dev-docstrings.qmd
+            - get-started/dev-renderers.qmd
         - section: "Extra Topics"
           contents:
             - get-started/extra-build-sequence.qmd


### PR DESCRIPTION
This small PR fixes a couple pages being excluded because they were renamed

![image](https://user-images.githubusercontent.com/2574498/235498746-29999c11-e705-4be7-acf3-95011c51ceaf.png)
