### PR TITLE
docs: correctly escape when mentioning quarto block

### DIFF
--- a/docs/get-started/docstring-examples.qmd
+++ b/docs/get-started/docstring-examples.qmd
@@ -42,7 +42,6 @@ Below is an example including each.
     ```
     
     quarto syntax:
-    note that the "\" should be removed.
     
     ```{{python}}
     1 + 1

--- a/docs/get-started/docstring-examples.qmd
+++ b/docs/get-started/docstring-examples.qmd
@@ -44,7 +44,7 @@ Below is an example including each.
     quarto syntax:
     note that the "\" should be removed.
     
-    ```\{python}
+    ```{{python}}
     1 + 1
     ```
 ```


### PR DESCRIPTION
Fixes a small issue, where I didn't know how to escape a quarto block, so used a `\` as a placeholder.

See the quarto docs on escaping unexecuted blocks: https://quarto.org/docs/computations/execution-options.html#unexecuted-blocks