### PR TITLE
docs: how to document classes

### DIFF
--- a/docs/get-started/docstring-examples.qmd
+++ b/docs/get-started/docstring-examples.qmd
@@ -138,10 +138,7 @@ Linking to functions documented outside your package must be configured in the [
 
 See [this numpydoc page on documenting classes](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes).
 
-Be sure to note these two important pieces:
-
-* Document your `__init__` method parameters on the class docstring.
-* You can use an `Attributes` section in your docstring.
+Below is a simple example of a class docstring.
 
 ```python
 class MyClass:
@@ -165,3 +162,9 @@ class MyClass:
     def __init__(self, a: str):
         self.a = a
 ```
+
+Note these two important pieces:
+
+* Document your `__init__` method parameters on the class docstring.
+* You can use an `Attributes` section in your docstring.
+

--- a/docs/get-started/docstring-examples.qmd
+++ b/docs/get-started/docstring-examples.qmd
@@ -132,3 +132,13 @@ def f():
 :::{.callout-note}
 Linking to functions documented outside your package must be configured in the [interlinks filter](./interlinks.qmd).
 :::
+
+
+## How do I document a class?
+
+See [this numpydoc page on documenting classes](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes).
+
+Be sure to note these two important pieces:
+
+* Document your `__init__` method parameters on the class docstring.
+* You can use an `Attributes` section in your docstring.

--- a/docs/get-started/docstring-examples.qmd
+++ b/docs/get-started/docstring-examples.qmd
@@ -142,3 +142,26 @@ Be sure to note these two important pieces:
 
 * Document your `__init__` method parameters on the class docstring.
 * You can use an `Attributes` section in your docstring.
+
+```python
+class MyClass:
+    """A great class.
+
+    Parameters
+    ----------
+    a:
+        Some parameter.
+
+    Attributes
+    ----------
+    x:
+        An integer
+    """
+
+
+    x: int = 1
+
+
+    def __init__(self, a: str):
+        self.a = a
+```


### PR DESCRIPTION
This PR adds some notes on documenting class docstrings, and points to the numpydoc section on it.