### PR TITLE
fix: support griffe v0.28

### DIFF
--- a/quartodoc/ast.py
+++ b/quartodoc/ast.py
@@ -28,7 +28,7 @@ def transform(el):
 
     # patch a list of docstring sections. note that this has to happen on the
     # list, since we replace single nodes on the tree (the list is the node).
-    elif isinstance(el, list) and len(el) and isinstance(el[0], dc.DocstringSection):
+    elif isinstance(el, list) and len(el) and isinstance(el[0], ds.DocstringSection):
         return _DocstringSectionPatched.transform_all(el)
 
     return el
@@ -47,8 +47,8 @@ class _DocstringSectionPatched(ds.DocstringSection):
     _registry: "dict[Enum, _DocstringSectionPatched]" = {}
 
     def __init__(self, value: str, title: "str | None" = None):
-        self.value = value
         super().__init__(title)
+        self.value = value
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -5,13 +5,19 @@ import quartodoc.ast as qast
 from contextlib import contextmanager
 from griffe.docstrings import dataclasses as ds
 from griffe import dataclasses as dc
-from griffe import expressions as expr
 from tabulate import tabulate
 from plum import dispatch
 from typing import Tuple, Union, Optional
 from quartodoc import layout
 
 from .base import Renderer, escape, sanitize, convert_rst_link_to_md
+
+
+try:
+    # Name and Expression were moved to expressions in v0.28
+    from griffe import expressions as expr
+except ImportError:
+    from griffe import dataclasses as expr
 
 
 def _has_attr_section(el: dc.Docstring | None):

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -5,6 +5,7 @@ import quartodoc.ast as qast
 from contextlib import contextmanager
 from griffe.docstrings import dataclasses as ds
 from griffe import dataclasses as dc
+from griffe import expressions as expr
 from tabulate import tabulate
 from plum import dispatch
 from typing import Tuple, Union, Optional
@@ -95,7 +96,7 @@ class MdRenderer(Renderer):
 
         raise ValueError(f"Unsupported display_name: `{self.display_name}`")
 
-    def render_annotation(self, el: "str | dc.Name | dc.Expression | None"):
+    def render_annotation(self, el: "str | expr.Name | expr.Expression | None"):
         """Special hook for rendering a type annotation.
 
         Parameters
@@ -110,7 +111,7 @@ class MdRenderer(Renderer):
 
         # TODO: maybe there is a way to get tabulate to handle this?
         # unescaped pipes screw up table formatting
-        if isinstance(el, dc.Name):
+        if isinstance(el, expr.Name):
             return sanitize(el.source)
 
         return sanitize(el.full)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ zipsafe = False
 
 python_requires = >=3.9
 install_requires =
-    griffe==0.25
+    griffe
     plum-dispatch<2.0.0;python_version<'3.10'
     plum-dispatch;python_version>='3.10'
     sphobjinv


### PR DESCRIPTION
This PR enables support for griffe v0.28 by changing imports for two classes that were moved...

```
# previously
from griffe.dataclasses import Name, Expression

# now
from griffe.expressions import Name, Expression
```

Note that this ~~breaks backwards compatibility~~ (edit: nvm just used a try/except import) with previous versions of griffe, so we'll need to update the renderers in siuba and pyshiny.