### PR TITLE
dev: remove python 3.8 tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ author_email = mc_al_github@fastmail.com
 license = MIT
 keywords = documentation, quarto
 classifiers =
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 


### PR DESCRIPTION
Addresses https://github.com/machow/quartodoc/issues/169 by removing the python 3.8 tag from PyPI