### PR TITLE
fix: correct sidebar structure

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -522,7 +522,8 @@ class Builder:
 
             contents.append({"section": section.title, "contents": links})
 
-        return {"website": {"sidebar": {"id": self.dir, "contents": contents}}}
+        entries = [{"id": self.dir, "contents": contents}, {"id": "dummy-sidebar"}]
+        return {"website": {"sidebar": entries}}
 
     def write_sidebar(self, blueprint: layout.Layout):
         """Write a yaml config file for API sidebar."""


### PR DESCRIPTION
This PR fixes the sidebar yaml to make our side entry a list. Let's wait and see the response to https://github.com/quarto-dev/quarto-cli/issues/5689, before potentially adding a dummy id entry / seeing if we should be configuring the sidebar another way)