### PR TITLE
Fix dynamic class loading

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -202,7 +202,14 @@ def replace_docstring(obj: dc.Object | dc.Alias, f=None):
         mod = importlib.import_module(obj.module.canonical_path)
 
         if isinstance(obj.parent, dc.Class):
-            f = getattr(getattr(mod, obj.parent.name), obj.name)
+            parent_obj = getattr(mod, obj.parent.name)
+
+            # we might fail to get the attribute if it is only a type annotation,
+            # and in that case need to bail out of the docstring replacement
+            try:
+                f = getattr(parent_obj, obj.name)
+            except AttributeError:
+                return
         else:
             f = getattr(mod, obj.name)
 

--- a/quartodoc/tests/example_dynamic.py
+++ b/quartodoc/tests/example_dynamic.py
@@ -30,6 +30,7 @@ class AClass:
 
 class InstanceAttrs:
     z: int
+    """The z attribute"""
 
     def __init__(self, a: int, b: str):
         self.a = a

--- a/quartodoc/tests/example_dynamic.py
+++ b/quartodoc/tests/example_dynamic.py
@@ -26,3 +26,12 @@ class AClass:
     # correctly set its __doc__ attribute in that case.
     dynamic_create = partial(dynamic_doc, x=1)
     dynamic_create.__doc__ = dynamic_doc.__doc__
+
+
+class InstanceAttrs:
+    z: int
+
+    def __init__(self, a: int, b: str):
+        self.a = a
+        self.b = b
+        """The b attribute"""

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -84,3 +84,9 @@ def test_get_object_dynamic_class_method_doc():
 
     meth = obj.members["dynamic_create"]
     assert meth.docstring.value == "A dynamic method"
+
+
+def test_get_object_dynamic_class_instance_attr_doc():
+    obj = get_object("quartodoc.tests.example_dynamic:InstanceAttrs", dynamic=True)
+
+    assert obj.members["b"].docstring.value == "The b attribute"

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -90,3 +90,9 @@ def test_get_object_dynamic_class_instance_attr_doc():
     obj = get_object("quartodoc.tests.example_dynamic:InstanceAttrs", dynamic=True)
 
     assert obj.members["b"].docstring.value == "The b attribute"
+
+
+def test_get_object_dynamic_class_instance_attr_doc():
+    obj = get_object("quartodoc.tests.example_dynamic:InstanceAttrs", dynamic=True)
+
+    assert obj.members["z"].docstring.value == "The z attribute"


### PR DESCRIPTION
This PR fixes issues with loading classes (and their members) dynamically. Namely, it tries to gracefully fall back to static loading for instance and class variables with no values (which can't be loaded, because there's nothing there, but may have docstrings that can be loaded by sphinx/griffe).

This is part of progress toward

* #133 