### PR TITLE
Feat canonical collect

### DIFF
--- a/quartodoc/builder/collect.py
+++ b/quartodoc/builder/collect.py
@@ -39,8 +39,17 @@ class CollectTransformer(PydanticTransformer):
         p_el = page_node.value
 
         uri = f"{self.base_dir}/{p_el.path}.html#{el.anchor}"
+
+        # item corresponding to the specified path ----
+        # e.g. this might be a top-level import
         self.items.append(
             layout.Item(name=el.obj.path, obj=el.obj, uri=uri, dispname=None)
+        )
+
+        # item corresponding to the canonical path ----
+        # this is where the object is defined (which may be deep in a submodule)
+        self.items.append(
+            layout.Item(name=el.obj.canonical_path, obj=el.obj, uri=uri, dispname=None)
         )
 
         return el

--- a/quartodoc/builder/collect.py
+++ b/quartodoc/builder/collect.py
@@ -40,17 +40,23 @@ class CollectTransformer(PydanticTransformer):
 
         uri = f"{self.base_dir}/{p_el.path}.html#{el.anchor}"
 
+        name_path = el.obj.path
+        canonical_path = el.obj.canonical_path
+
         # item corresponding to the specified path ----
         # e.g. this might be a top-level import
         self.items.append(
-            layout.Item(name=el.obj.path, obj=el.obj, uri=uri, dispname=None)
+            layout.Item(name=name_path, obj=el.obj, uri=uri, dispname=None)
         )
 
-        # item corresponding to the canonical path ----
-        # this is where the object is defined (which may be deep in a submodule)
-        self.items.append(
-            layout.Item(name=el.obj.canonical_path, obj=el.obj, uri=uri, dispname=None)
-        )
+        if name_path != canonical_path:
+            # item corresponding to the canonical path ----
+            # this is where the object is defined (which may be deep in a submodule)
+            self.items.append(
+                layout.Item(
+                    name=canonical_path, obj=el.obj, uri=uri, dispname=name_path
+                )
+            )
 
         return el
 


### PR DESCRIPTION
This PR addresses #88, by adding an extra inventory item corresponding to the canonical path of the collected object.

This is important for packages like py-shiny, which may import annotations from various places (e.g. both `htmltools._core.Tag` and `htmltools.Tag`). Previously, only the latter would produce a clickable interlink.