### PR TITLE
DRAFT: remove elements with custom py objects from layout

### DIFF
--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -142,7 +142,7 @@ class Interlaced(_Docable):
 
     # note that this is similar to a ContentList, except it cannot include
     # elements like Pages, etc..
-    contents: list[Union[Auto, Doc, _AutoDefault]]
+    contents: list[Union[Auto, _AutoDefault]]
 
     @property
     def name(self):
@@ -341,7 +341,7 @@ ContentElement = Annotated[
 ]
 """Entry in the contents list."""
 
-ContentList = list[Union[ContentElement, Doc, _AutoDefault]]
+ContentList = list[Union[ContentElement, _AutoDefault]]
 
 # Item ----
 


### PR DESCRIPTION
Part of 

* #185 

This PR removes elements with custom python objects from the pydantic model for Layout, so that we can research using the model's jsonschema as part of quarto validation