### PR TITLE
feat: add subtitle option to section

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -130,38 +130,33 @@ quartodoc:
         - create_inventory
         - convert_inventory
 
-    - title: "Data models: structural"
+    - title: "Data models"
+
+    - subtitle: "Structural"
       desc: |
         Classes for specifying the broad structure your docs.
       contents:
-        - kind: "page"
-          path: "layouts-structure"
-          flatten: true
-          contents:
-            - layout.Layout
-            - layout.Section
-            - layout.Page
-            - layout.SectionElement
-            - layout.ContentElement
+        - layout.Layout
+        - layout.Section
+        - layout.Page
+        - layout.SectionElement
+        - layout.ContentElement
 
-    - title: "Data models: docable"
+    - subtitle: "Docable"
       desc: |
         Classes representing python objects to be rendered.
       contents:
-        - kind: "page"
-          path: "layouts-docable"
-          flatten: true
-          contents:
-            - name: layout.Doc
-              members: []
-            - layout.DocFunction
-            - layout.DocAttribute
-            - layout.DocModule
-            - layout.DocClass
-            - layout.Link
-            - layout.Item
-            - layout.ChoicesChildren
-    - title: "Data models: docstring patches"
+        - name: layout.Doc
+          members: []
+        - layout.DocFunction
+        - layout.DocAttribute
+        - layout.DocModule
+        - layout.DocClass
+        - layout.Link
+        - layout.Item
+        - layout.ChoicesChildren
+
+    - subtitle: "Docstring patches"
       desc: |
         Most of the classes for representing python objects live
         in [](`griffe.dataclasses`) or [](`griffe.docstrings.dataclasses`).

--- a/docs/get-started/basic-content.qmd
+++ b/docs/get-started/basic-content.qmd
@@ -95,8 +95,34 @@ quartodoc:
         # set the children option, so that methods get documented
         # on separate pages. MdRenderer's docs will include a summary
         # table that links to each page.
-        - name: quartodoc.MdRenderer
+        - name: MdRenderer
           children: separate
+```
+
+## Reference page sub-sections
+
+quartodoc supports two levels of grouping on the reference page.
+Use the `subtitle:` option to add an additional level of grouping.
+
+For example, the code below creates an API reference page with one top-level section ("Some section"),
+with two sub-sections inside it.
+
+
+```yaml
+quartodoc:
+  package: quartodoc
+  sections:
+    - title: Some section
+
+    - subtitle: Stuff A
+      desc: This is subsection A
+      contents:
+        - MdRenderer
+
+    - subtitle: Stuff B
+      desc: This is subsection B
+      contents:
+        - get_object
 ```
 
 ## Grouping on a page

--- a/docs/get-started/basic-docs.qmd
+++ b/docs/get-started/basic-docs.qmd
@@ -46,9 +46,10 @@ print(renderer.render(doc_params))
 
 The `sections` field defines which functions to document.
 
-It requires three pieces of configuration:
+It commonly requires three pieces of configuration:
 
 * `title`: a title for the section
 * `desc`: a description for the section
 * `contents`: a list of functions to document
 
+You can also replace `title` with `subtitle` to create a sub-section.

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -36,10 +36,29 @@ html { font-family: 'Inter', sans-serif; }
   line-height: 22px;
 }
 
+.sidebar-item {
+  margin-top: 0px;
+}
+
 .sidebar-item-section {
   padding-top: 16px;
 }
 
 .sidebar-section {
   padding-left: 0px !important;
+}
+
+.sidebar-item-section .sidebar-item-section {
+  padding-top: 0px;
+  padding-left: 10px;
+}
+
+
+td:first-child {
+  text-wrap: nowrap;
+  text-size-adjust: 100%;
+}
+
+td:first-child a {
+  word-break: normal;
 }

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -558,12 +558,30 @@ class Builder:
 
     def _generate_sidebar(self, blueprint: layout.Layout):
         contents = [f"{self.dir}/index{self.out_page_suffix}"]
+        in_subsection = False
+        crnt_entry = {}
         for section in blueprint.sections:
+            if section.title:
+                if crnt_entry:
+                    contents.append(crnt_entry)
+
+                in_subsection = False
+                crnt_entry = {"section": section.title, "contents": []}
+            elif section.subtitle:
+                in_subsection = True
+
             links = []
             for entry in section.contents:
                 links.extend(self._page_to_links(entry))
 
-            contents.append({"section": section.title, "contents": links})
+            if in_subsection:
+                sub_entry = {"section": section.subtitle, "contents": links}
+                crnt_entry["contents"].append(sub_entry)
+            else:
+                crnt_entry["contents"].extend(links)
+
+        if crnt_entry:
+            contents.append(crnt_entry)
 
         return {"website": {"sidebar": {"id": self.dir, "contents": contents}}}
 

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -58,6 +58,9 @@ class Section(_Structural):
     kind:
     title:
         Title of the section on the index.
+    subtitle:
+        Subtitle of the section on the index. Note that either title or subtitle,
+        but not both, may be set.
     desc:
         Description of the section on the index.
     package:
@@ -67,10 +70,22 @@ class Section(_Structural):
     """
 
     kind: Literal["section"] = "section"
-    title: str
-    desc: str
+    title: Optional[str] = None
+    subtitle: Optional[str] = None
+    desc: Optional[str] = None
     package: Union[str, None, MISSING] = MISSING()
-    contents: ContentList
+    contents: Optional[ContentList] = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+        # TODO: should these be a custom type? Or can we use pydantic's ValidationError?
+        if self.title is None and self.subtitle is None and self.contents is None:
+            raise ValueError(
+                "Section must specify a title, subtitle, or contents field"
+            )
+        elif self.title is not None and self.subtitle is not None:
+            raise ValueError("Section cannot specify both title and subtitle fields.")
 
 
 class SummaryDetails(_Base):

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -74,13 +74,13 @@ class Section(_Structural):
     subtitle: Optional[str] = None
     desc: Optional[str] = None
     package: Union[str, None, MISSING] = MISSING()
-    contents: Optional[ContentList] = None
+    contents: ContentList = []
 
     def __init__(self, **data):
         super().__init__(**data)
 
         # TODO: should these be a custom type? Or can we use pydantic's ValidationError?
-        if self.title is None and self.subtitle is None and self.contents is None:
+        if self.title is None and self.subtitle is None and not self.contents:
             raise ValueError(
                 "Section must specify a title, subtitle, or contents field"
             )

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -528,16 +528,23 @@ class MdRenderer(Renderer):
 
     @dispatch
     def summarize(self, el: layout.Section):
-        header = f"## {el.title}\n\n{el.desc}"
+        desc = f"\n\n{el.desc}" if el.desc is not None else ""
+        if el.title is not None:
+            header = f"## {el.title}{desc}"
+        elif el.subtitle is not None:
+            header = f"### {el.subtitle}{desc}"
 
-        thead = "| | |\n| --- | --- |"
+        if el.contents:
+            thead = "| | |\n| --- | --- |"
 
-        rendered = []
-        for child in el.contents:
-            rendered.append(self.summarize(child))
+            rendered = []
+            for child in el.contents:
+                rendered.append(self.summarize(child))
 
-        str_func_table = "\n".join([thead, *rendered])
-        return f"{header}\n\n{str_func_table}"
+            str_func_table = "\n".join([thead, *rendered])
+            return f"{header}\n\n{str_func_table}"
+        
+        return header
 
     @dispatch
     def summarize(self, el: layout.Page):

--- a/quartodoc/tests/__snapshots__/test_builder.ambr
+++ b/quartodoc/tests/__snapshots__/test_builder.ambr
@@ -3,7 +3,7 @@
   '''
   website:
     sidebar:
-      contents:
+    - contents:
       - reference/index.qmd
       - contents:
         - reference/a_func.qmd
@@ -14,6 +14,7 @@
           section: a subsection
         section: second section
       id: reference
-
+    - id: dummy-sidebar
+  
   '''
 # ---

--- a/quartodoc/tests/__snapshots__/test_builder.ambr
+++ b/quartodoc/tests/__snapshots__/test_builder.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_builder_generate_sidebar
+  '''
+  website:
+    sidebar:
+      contents:
+      - reference/index.qmd
+      - contents:
+        - reference/a_func.qmd
+        section: first section
+      - contents:
+        - contents:
+          - reference/a_attr.qmd
+          section: a subsection
+        section: second section
+      id: reference
+
+  '''
+# ---

--- a/quartodoc/tests/test_builder.py
+++ b/quartodoc/tests/test_builder.py
@@ -1,8 +1,9 @@
 import pytest
+import yaml
 
 from pathlib import Path
 from quartodoc import layout as lo
-from quartodoc import Builder
+from quartodoc import Builder, blueprint
 
 
 @pytest.fixture
@@ -40,3 +41,28 @@ def test_builder_build_filter_wildcard_methods(builder):
     builder.build(filter="MdRenderer.*")
 
     len(list(Path(builder.dir).glob("Mdrenderer.*"))) == 2
+
+
+def test_builder_generate_sidebar(tmp_path, snapshot):
+    cfg = yaml.safe_load(
+        """
+    quartodoc:
+      package: quartodoc.tests.example
+      sections:
+        - title: first section
+          desc: some description
+          contents: [a_func]
+        - title: second section
+          desc: title description
+        - subtitle: a subsection
+          desc: subtitle description
+          contents:
+            - a_attr
+    """
+    )
+
+    builder = Builder.from_quarto_config(cfg)
+    bp = blueprint(builder.layout)
+    d_sidebar = builder._generate_sidebar(bp)
+
+    assert yaml.dump(d_sidebar) == snapshot

--- a/quartodoc/tests/test_layout.py
+++ b/quartodoc/tests/test_layout.py
@@ -27,3 +27,17 @@ def test_layout_from_config(cfg, res):
 
     layout = Layout(sections=[cfg])
     assert layout.sections[0] == res
+
+
+@pytest.mark.parametrize(
+    "kwargs, msg_part",
+    [
+        ({}, "must specify a title, subtitle, or contents field"),
+        ({"title": "x", "subtitle": "y"}, "cannot specify both"),
+    ],
+)
+def test_section_validation_fails(kwargs, msg_part):
+    with pytest.raises(ValueError) as exc_info:
+        Section(**kwargs)
+
+    assert msg_part in exc_info.value.args[0]

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -2,7 +2,8 @@ import pytest
 import griffe.docstrings.dataclasses as ds
 
 from quartodoc.renderers import MdRenderer
-from quartodoc import get_object
+from quartodoc import layout
+from quartodoc import get_object, blueprint
 
 
 @pytest.fixture
@@ -60,3 +61,30 @@ def test_render_table_description_interlink(renderer, pair):
 
     res = renderer.render(pars)
     assert interlink in res
+
+
+@pytest.mark.parametrize(
+    "section, dst",
+    [
+        (layout.Section(title="abc"), "## abc"),
+        (layout.Section(subtitle="abc"), "### abc"),
+        (layout.Section(title="abc", desc="zzz"), "## abc\n\nzzz"),
+        (layout.Section(subtitle="abc", desc="zzz"), "### abc\n\nzzz"),
+    ],
+)
+def test_render_summarize_section_title(renderer, section, dst):
+    res = renderer.summarize(section)
+
+    assert res == dst
+
+
+def test_render_summarize_section_contents(renderer):
+    obj = blueprint(layout.Auto(name="a_func", package="quartodoc.tests.example"))
+    section = layout.Section(title="abc", desc="zzz", contents=[obj])
+    res = renderer.summarize(section)
+
+    table = (
+        "| | |\n| --- | --- |\n"
+        "| [a_func](#quartodoc.tests.example.a_func) | A function |"
+    )
+    assert res == f"## abc\n\nzzz\n\n{table}"

--- a/quartodoc/tests/test_validation.py
+++ b/quartodoc/tests/test_validation.py
@@ -1,65 +1,79 @@
-import pytest, copy
+import copy
+import pytest
+
 from quartodoc.autosummary import Builder
 
 EXAMPLE_SECTIONS = [
-                  {'title':  'Preperation Functions',
-                   'desc': 'Functions that fetch objects.\nThey prepare a representation of the site.\n', 
-                   'contents': ['Auto', 'blueprint', 'collect', 'get_object', 'preview']}, 
-                  {'title': 'Docstring Renderers', 
-                   'desc': 'Renderers convert parsed docstrings into a target format, like markdown.\n', 
-                   'contents': [{'name': 'MdRenderer', 'children': 'linked'}, 
-                                {'name': 'MdRenderer.render', 'dynamic': True}, 
-                                {'name': 'MdRenderer.render_annotation', 'dynamic': True}, 
-                                {'name': 'MdRenderer.render_header', 'dynamic': True}]
-                    }, 
-                    {'title': 'API Builders', 
-                     'desc': 'Builders build documentation. They tie all the pieces\nof quartodoc together.\n', 
-                     'contents': [{'kind': 'auto', 'name': 'Builder', 'members': []}, 
-                                   'Builder.from_quarto_config', 'Builder.build', 'Builder.write_index']
-                    },
-                ]
+    {
+        "title": "Preperation Functions",
+        "desc": "Functions that fetch objects.\nThey prepare a representation of the site.\n",
+        "contents": ["Auto", "blueprint", "collect", "get_object", "preview"],
+    },
+    {
+        "title": "Docstring Renderers",
+        "desc": "Renderers convert parsed docstrings into a target format, like markdown.\n",
+        "contents": [
+            {"name": "MdRenderer", "children": "linked"},
+            {"name": "MdRenderer.render", "dynamic": True},
+            {"name": "MdRenderer.render_annotation", "dynamic": True},
+            {"name": "MdRenderer.render_header", "dynamic": True},
+        ],
+    },
+    {
+        "title": "API Builders",
+        "desc": "Builders build documentation. They tie all the pieces\nof quartodoc together.\n",
+        "contents": [
+            {"kind": "auto", "name": "Builder", "members": []},
+            "Builder.from_quarto_config",
+            "Builder.build",
+            "Builder.write_index",
+        ],
+    },
+]
+
 
 @pytest.fixture
 def sections():
     return copy.deepcopy(EXAMPLE_SECTIONS)
 
+
 def check_ValueError(sections):
     "Check that a ValueError is raised when creating a `Builder` instance. Return the error message as a string."
     with pytest.raises(ValueError) as e:
-        Builder(sections=sections, package='quartodoc')
+        Builder(sections=sections, package="quartodoc")
     return str(e.value)
+
 
 def test_valid_yaml(sections):
     "Test that valid YAML passes validation"
-    Builder(sections=sections, package='quartodoc')
+    Builder(sections=sections, package="quartodoc")
 
-def test_missing_title(sections):
-    "Test that missing title raises an error"
-    del sections[0]['title']
-    msg = check_ValueError(sections)
-    assert '- Missing field `title` for element 0 in the list for `sections`' in msg
-
-def test_missing_desc(sections):
-    "Test that a missing description raises an error"
-    sections = copy.deepcopy(EXAMPLE_SECTIONS)
-    del sections[2]['desc']
-    msg = check_ValueError(sections)
-    assert '- Missing field `desc` for element 2 in the list for `sections`' in msg
 
 def test_missing_name_contents_1(sections):
     "Test that a missing name in contents raises an error"
-    del sections[2]['contents'][0]['name']
+    del sections[2]["contents"][0]["name"]
     msg = check_ValueError(sections)
-    assert '- Missing field `name` for element 0 in the list for `contents` located in element 2 in the list for `sections`' in msg
+    assert (
+        "- Missing field `name` for element 0 in the list for `contents` located in element 2 in the list for `sections`"
+        in msg
+    )
+
 
 def test_missing_name_contents_2(sections):
     "Test that a missing name in contents raises an error in a different section."
-    del sections[1]['contents'][0]['name']
+    del sections[1]["contents"][0]["name"]
     msg = check_ValueError(sections)
-    assert '- Missing field `name` for element 0 in the list for `contents` located in element 1 in the list for `sections`' in msg
+    assert (
+        "- Missing field `name` for element 0 in the list for `contents` located in element 1 in the list for `sections`"
+        in msg
+    )
+
 
 def test_misplaced_kindpage(sections):
     "Test that a misplaced kind: page raises an error"
-    sections[0]['kind'] = 'page'
+    sections[0]["kind"] = "page"
     msg = check_ValueError(sections)
-    assert ' - Missing field `path` for element 0 in the list for `sections`, which you need when setting `kind: page`.' in msg
+    assert (
+        " - Missing field `path` for element 0 in the list for `sections`, which you need when setting `kind: page`."
+        in msg
+    )


### PR DESCRIPTION
This PR address #183, by enabling users to create subtitles in their config. It also supports the encouraged workflow in pkgdown, where an entry might be only a title, or subtitle.

e.g.

```yaml
sections:
  - title: a title
  - subtitle: a subtitle
  - contents:
    - abc
    - def
```

TODO:

- [x] : support sidebar generation