### PR TITLE
fix: better messaging when can't find an object

### DIFF
--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -54,11 +54,15 @@ class BlueprintTransformer(PydanticTransformer):
 
         return f"{path}:{new}"
 
-    def get_object_fixed(self, *args, **kwargs):
+    def get_object_fixed(self, path, **kwargs):
         try:
-            return self.get_object(*args, **kwargs)
+            return self.get_object(path, **kwargs)
         except KeyError as e:
-            raise WorkaroundKeyError(e.args[0])
+            key_name = e.args[0]
+            raise WorkaroundKeyError(
+                f"Cannot find an object named: {key_name}."
+                f" Does an object with the path {path} exist?"
+            )
 
     @dispatch
     def visit(self, el):

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -1,6 +1,10 @@
 from quartodoc import get_object
 from quartodoc import layout as lo
-from quartodoc.builder.blueprint import BlueprintTransformer, blueprint
+from quartodoc.builder.blueprint import (
+    BlueprintTransformer,
+    blueprint,
+    WorkaroundKeyError,
+)
 import pytest
 
 TEST_MOD = "quartodoc.tests.example"
@@ -90,3 +94,15 @@ def test_blueprint_auto_package(bp):
     assert isinstance(res, lo.DocFunction)
     assert res.name == "a_func"
     assert res.anchor == "quartodoc.tests.example.a_func"
+
+
+def test_blueprint_lookup_error_message(bp):
+    auto = lo.Auto(name="quartodoc.bbb.ccc")
+
+    with pytest.raises(WorkaroundKeyError) as exc_info:
+        bp.visit(auto)
+
+    assert (
+        "Does an object with the path quartodoc.bbb.ccc exist?"
+        in exc_info.value.args[0]
+    )


### PR DESCRIPTION
This PR addresses #159 , by adding a more specific error when an object can't be found during blueprinting.

E.g. including the sentence "Does an object with the path quartodoc.bbb.ccc exist?"