### PR TITLE
fix: do not render attribute annotations twice

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -438,10 +438,9 @@ class MdRenderer(Renderer):
 
     @dispatch
     def render(self, el: ds.DocstringAttribute):
-        annotation = self.render_annotation(el.annotation)
         row = [
             sanitize(el.name),
-            self.render_annotation(annotation),
+            self.render_annotation(el.annotation),
             sanitize(el.description or "", allow_markdown=True)
         ]
         return row

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -1,5 +1,6 @@
 import pytest
 import griffe.docstrings.dataclasses as ds
+import griffe.expressions as exp
 
 from quartodoc.renderers import MdRenderer
 from quartodoc import get_object
@@ -60,3 +61,17 @@ def test_render_table_description_interlink(renderer, pair):
 
     res = renderer.render(pars)
     assert interlink in res
+
+
+def test_render_doc_attribute(renderer):
+    attr = ds.DocstringAttribute(
+        name = "abc",
+        description="xyz",
+        annotation=exp.Expression(exp.Name("Optional", full="Optional"), "[", "]"),
+        value=1
+    )
+
+    res = renderer.render(attr)
+
+    assert res == ["abc", "Optional\[\]", "xyz"]
+


### PR DESCRIPTION
Addresses an issue pointed out by @schloerke -- we are rendering annotations twice for attributes. This can cause issues like sanitizing twice, etc...