### PR TITLE
Use italics when rendering a "required" default value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,8 @@ on:
     types: [published]
 
 jobs:
-  run-if:
-    name: "Run If"
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    steps:
-      - run: |
-          echo "Running CI"
   test:
     name: "Test"
-    needs: ["run-if"]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -421,7 +421,7 @@ class MdRenderer(Renderer):
     @dispatch
     def render(self, el: ds.DocstringParameter) -> Tuple[str]:
         # TODO: if default is not, should return the word "required" (unescaped)
-        default = "required" if el.default is None else escape(el.default)
+        default = "_required_" if el.default is None else escape(el.default)
 
         annotation = self.render_annotation(el.annotation)
         clean_desc = sanitize(el.description, allow_markdown=True)


### PR DESCRIPTION
It is nice to differentiate more when displaying the default function param value.

Before:
![Screenshot 2023-06-29 at 4 38 21 PM](https://github.com/machow/quartodoc/assets/93231/378e4505-1038-4a69-9739-9a68f4bd50b1)

With PR:
![Screenshot 2023-06-29 at 4 37 16 PM](https://github.com/machow/quartodoc/assets/93231/d5b574c6-41fc-4e2b-b226-c8b4076aa554)
