### PR TITLE
Feat automodule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ".*\\.(csv)|(md)|(json)"
+exclude: ".*\\.(csv)|(md)|(json)|(ambr)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ $(EXAMPLE_INTERLINKS)/test.md: $(EXAMPLE_INTERLINKS)/test.qmd _extensions/interl
 
 examples/%/_site: examples/%/_quarto.yml
 	cd examples/$* \
-		&& quarto add --no-prompt ../.. \
-		&& quarto add --no-prompt quarto-ext/shinylive
+		&& quarto add --no-prompt ../..
 	cd examples/$* && quartodoc build _quarto.yml --verbose
 	cd examples/$* && quartodoc interlinks
 	quarto render $(dir $<)
@@ -30,7 +29,7 @@ docs/examples/%: examples/%/_site
 	rm -rf docs/examples/$*
 	cp -rv $< $@
 
-docs-build-examples: docs/examples/single-page docs/examples/pkgdown
+docs-build-examples: docs/examples/single-page docs/examples/pkgdown docs/examples/auto-package
 
 docs-build: docs-build-examples
 	cd docs && quarto add --no-prompt ..

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -4,6 +4,7 @@ project:
   resources:
     - examples/single-page
     - examples/pkgdown
+    - examples/auto-package
 
 metadata-files:
   - api/_sidebar.yml

--- a/examples/auto-package/_quarto.yml
+++ b/examples/auto-package/_quarto.yml
@@ -1,0 +1,25 @@
+project:
+  type: website
+  resources:
+    - objects.json
+
+website:
+  title: pkgdown example
+  navbar:
+    left:
+      - href: https://machow.github.io/quartodoc/
+        text: quartodoc home
+      - file: reference/index.qmd
+        text: "Reference"
+    right:
+      - icon: github
+        href: https://github.com/machow/quartodoc/tree/main/examples/pkgdown
+
+format:
+  html:
+    toc: true
+
+quartodoc:
+  style: pkgdown
+  dir: reference
+  package: quartodoc

--- a/quartodoc/__init__.py
+++ b/quartodoc/__init__.py
@@ -1,15 +1,25 @@
+"""quartodoc is a package for building delightful python API documentation.
+"""
+
 # flake8: noqa
 
-from .autosummary import (
-    get_function,
-    get_object,
-    Builder,
-    BuilderPkgdown,
-    BuilderSinglePage,
-)
+from .autosummary import get_function, get_object, Builder
 from .renderers import MdRenderer
 from .inventory import convert_inventory, create_inventory
 from .ast import preview
 from .builder.blueprint import blueprint
 from .builder.collect import collect
 from .layout import Auto
+
+__all__ = (
+    "Auto" "blueprint",
+    "collect",
+    "convert_inventory",
+    "create_inventory",
+    "get_object",
+    "preview",
+    "Builder",
+    "BuilderPkgdown",
+    "BuilderSinglePage",
+    "MdRenderer",
+)

--- a/quartodoc/__init__.py
+++ b/quartodoc/__init__.py
@@ -12,7 +12,8 @@ from .builder.collect import collect
 from .layout import Auto
 
 __all__ = (
-    "Auto" "blueprint",
+    "Auto",
+    "blueprint",
     "collect",
     "convert_inventory",
     "create_inventory",

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -427,6 +427,7 @@ class Builder:
         rewrite_all_pages=False,
         source_dir: "str | None" = None,
         dynamic: bool | None = None,
+        parser="numpy",
     ):
         self.layout = self.load_layout(sections=sections, package=package)
 
@@ -435,6 +436,7 @@ class Builder:
         self.dir = dir
         self.title = title
         self.sidebar = sidebar
+        self.parser = parser
 
         self.renderer = Renderer.from_config(renderer)
 
@@ -483,7 +485,7 @@ class Builder:
         # shaping and collection ----
 
         _log.info("Generating blueprint.")
-        blueprint = blueprint(self.layout, dynamic=self.dynamic)
+        blueprint = blueprint(self.layout, dynamic=self.dynamic, parser=self.parser)
 
         _log.info("Collecting pages and inventory items.")
         pages, items = collect(blueprint, base_dir=self.dir)

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -416,7 +416,8 @@ class Builder:
     def __init__(
         self,
         package: str,
-        sections: "list[Any]",
+        # TODO: correct typing
+        sections: "list[Any]" = tuple(),
         version: "str | None" = None,
         dir: str = "reference",
         title: str = "Function reference",
@@ -451,10 +452,12 @@ class Builder:
         try:
             return layout.Layout(sections=sections, package=package)
         except ValidationError as e:
-            msg = 'Configuration error for YAML:\n - '
+            msg = "Configuration error for YAML:\n - "
             errors = [fmt(err) for err in e.errors() if fmt(err)]
-            first_error = errors[0] # we only want to show one error at a time b/c it is confusing otherwise
-            msg += first_error           
+            first_error = errors[
+                0
+            ]  # we only want to show one error at a time b/c it is confusing otherwise
+            msg += first_error
             raise ValueError(msg) from None
 
     # building ----------------------------------------------------------------

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -270,6 +270,9 @@ class BlueprintTransformer(PydanticTransformer):
         if not el.include_private:
             options = {k: v for k, v in options.items() if not k.startswith("_")}
 
+        if not el.include_imports:
+            options = {k: v for k, v in options.items() if not v.is_alias}
+
         # for modules, remove any Alias objects, since they were imported from
         # other places. Sphinx has a flag for this behavior, so may be good
         # to do something similar.

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -9,6 +9,7 @@ from griffe.loader import GriffeLoader
 from griffe.collections import ModulesCollection, LinesCollection
 from griffe.docstrings.parsers import Parser
 from functools import partial
+from textwrap import indent
 
 from plum import dispatch
 
@@ -163,7 +164,10 @@ class BlueprintTransformer(PydanticTransformer):
             print(
                 "Use the following configuration to recreate the automatically",
                 " generated site:\n\n\n",
-                yaml.safe_dump(_to_simple_dict(new_el)),
+                "quartodoc:\n",
+                indent(
+                    yaml.safe_dump(_to_simple_dict(new_el), sort_keys=False), " " * 2
+                ),
                 "\n",
                 sep="",
             )

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -55,11 +55,11 @@ def _auto_package(mod: dc.Module) -> list[Section]:
     else:
         desc = ""
 
-    return [Section(title=mod.name, desc=desc, contents=contents)]
+    return [Section(title=mod.path, desc=desc, contents=contents)]
 
 
 def _is_external_alias(obj: dc.Alias | dc.Object, mod: dc.Module):
-    package_name = mod.name.split(".")[0]
+    package_name = mod.path.split(".")[0]
 
     if not isinstance(obj, dc.Alias):
         return False

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -132,7 +132,7 @@ class BlueprintTransformer(PydanticTransformer):
             new_el.sections = sections
 
             print(
-                "Use the following config configuration to recreate the automatically",
+                "Use the following configuration to recreate the automatically",
                 " generated site:\n\n\n",
                 yaml.safe_dump(_to_simple_dict(new_el)),
                 "\n",

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -70,9 +70,8 @@ def _is_external_alias(obj: dc.Alias | dc.Object, mod: dc.Module):
             return True
 
         try:
-            new_target = crnt_target.modules_collection.get_member(
-                crnt_target.target_path
-            )
+            new_target = crnt_target.modules_collection[crnt_target.target_path]
+
             if new_target is crnt_target:
                 raise Exception(f"Cyclic Alias: {new_target}")
 

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -41,7 +41,10 @@ def _auto_package(mod: dc.Module) -> list[Section]:
     # get module members for content ----
     contents = []
     for name, member in mod.members.items():
-        if member.is_module or name.startswith("__all__"):
+        external_alias = member.is_alias and not member.target_path.startswith(
+            mod.name.split(".")[0]
+        )
+        if external_alias or member.is_module or name.startswith("__"):
             continue
 
         contents.append(Auto(name=name))
@@ -268,7 +271,9 @@ def blueprint(el: Auto, package: str) -> Doc:
     ...
 
 
-def blueprint(el: _Base, package: str = None, dynamic: None | bool = None) -> _Base:
+def blueprint(
+    el: _Base, package: str = None, dynamic: None | bool = None, parser="numpy"
+) -> _Base:
     """Convert a configuration element to something that is ready to render.
 
     Parameters
@@ -293,7 +298,7 @@ def blueprint(el: _Base, package: str = None, dynamic: None | bool = None) -> _B
 
     """
 
-    trans = BlueprintTransformer()
+    trans = BlueprintTransformer(parser=parser)
 
     if package is not None:
         trans.crnt_package = package

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -46,7 +46,7 @@ class Layout(_Structural):
         The package being documented.
     """
 
-    sections: list[Union[SectionElement, Section]]
+    sections: list[Union[SectionElement, Section]] = []
     package: Union[str, None, MISSING] = MISSING()
 
 

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -196,6 +196,8 @@ class Auto(_Base):
         A list of members, such as attributes or methods on a class, to document.
     include_private:
         Whether to include members starting with "_"
+    include_imports:
+        Whether to include members that were imported from somewhere else.
     include:
         (Not implemented). A list of members to include.
     exclude:
@@ -216,6 +218,7 @@ class Auto(_Base):
     name: str
     members: Optional[list[str]] = None
     include_private: bool = False
+    include_imports: bool = False
     include: Optional[str] = None
     exclude: Optional[str] = None
     dynamic: Union[None, bool, str] = None

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -249,7 +249,7 @@ class MdRenderer(Renderer):
     def render(self, el: Union[layout.DocClass, layout.DocModule]):
         title = self.render_header(el)
 
-        extra_parts = []
+        attr_docs = []
         meth_docs = []
         class_docs = []
 
@@ -276,18 +276,18 @@ class MdRenderer(Renderer):
 
                 _attrs_table = "\n".join(map(self.summarize, raw_attrs))
                 attrs = f"{sub_header} Attributes\n\n{header}\n{_attrs_table}"
-                extra_parts.append(attrs)
+                attr_docs.append(attrs)
             
             # classes summary table ----
             if raw_classes:
                 _summary_table = "\n".join(map(self.summarize, raw_classes))
                 section_name = "Classes"
                 objs = f"{sub_header} {section_name}\n\n{header}\n{_summary_table}"
-                extra_parts.append(objs)
+                class_docs.append(objs)
 
                 n_incr = 1 if el.flat else 2
                 with self._increment_header(n_incr):
-                    class_docs = [self.render(x) for x in raw_classes if isinstance(x, layout.Doc)]
+                    class_docs.extend([self.render(x) for x in raw_classes if isinstance(x, layout.Doc)])
 
             # method summary table ----
             if raw_meths:
@@ -297,15 +297,15 @@ class MdRenderer(Renderer):
                     else "Functions"
                 )
                 objs = f"{sub_header} {section_name}\n\n{header}\n{_summary_table}"
-                extra_parts.append(objs)
+                meth_docs.append(objs)
 
                 # TODO use context manager, or context variable?
                 n_incr = 1 if el.flat else 2
                 with self._increment_header(n_incr):
-                    meth_docs = [self.render(x) for x in raw_meths if isinstance(x, layout.Doc)]
+                    meth_docs.extend([self.render(x) for x in raw_meths if isinstance(x, layout.Doc)])
 
         body = self.render(el.obj)
-        return "\n\n".join([title, body, *extra_parts, *meth_docs, *class_docs])
+        return "\n\n".join([title, body, *attr_docs, *class_docs, *meth_docs])
 
     @dispatch
     def render(self, el: layout.DocFunction):

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -285,7 +285,9 @@ class MdRenderer(Renderer):
                 objs = f"{sub_header} {section_name}\n\n{header}\n{_summary_table}"
                 extra_parts.append(objs)
 
-                class_docs = [self.render(x) for x in raw_classes if isinstance(x, layout.Doc)]
+                n_incr = 1 if el.flat else 2
+                with self._increment_header(n_incr):
+                    class_docs = [self.render(x) for x in raw_classes if isinstance(x, layout.Doc)]
 
             # method summary table ----
             if raw_meths:

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -122,6 +122,24 @@
   
   `tests.example.AClass()`
   
+  #### Attributes
+  
+  | Name | Description |
+  | --- | --- |
+  | [a_attr](#quartodoc.tests.example.AClass.a_attr) | A class attribute |
+  
+  #### Methods
+  
+  | Name | Description |
+  | --- | --- |
+  | [a_method](#quartodoc.tests.example.AClass.a_method) | A method |
+  
+  ##### a_method { #quartodoc.tests.example.AClass.a_method }
+  
+  `tests.example.AClass.a_method()`
+  
+  A method
+  
   ## Functions
   
   | Name | Description |
@@ -158,6 +176,24 @@
   ## AClass { #quartodoc.tests.example.AClass }
   
   `tests.example.AClass()`
+  
+  ### Attributes
+  
+  | Name | Description |
+  | --- | --- |
+  | [a_attr](#quartodoc.tests.example.AClass.a_attr) | A class attribute |
+  
+  ### Methods
+  
+  | Name | Description |
+  | --- | --- |
+  | [a_method](#quartodoc.tests.example.AClass.a_method) | A method |
+  
+  #### a_method { #quartodoc.tests.example.AClass.a_method }
+  
+  `tests.example.AClass.a_method()`
+  
+  A method
   
   ## Functions
   

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -1,0 +1,188 @@
+# serializer version: 1
+# name: test_render_doc_class[embedded]
+  '''
+  # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
+
+  `tests.example_class.C(self, x, y)`
+
+  The short summary.
+
+  The extended summary,
+  which may be multiple lines.
+
+  ## Parameters
+
+  | Name   | Type   | Description          | Default    |
+  |--------|--------|----------------------|------------|
+  | `x`    | str    | Uses signature type. | _required_ |
+  | `y`    | int    | Uses manual type.    | _required_ |
+
+  ## Attributes
+
+  | Name | Description |
+  | --- | --- |
+  | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
+  | [some_property](#quartodoc.tests.example_class.C.some_property) | A property |
+  | [x](#quartodoc.tests.example_class.C.x) |  |
+  | [y](#quartodoc.tests.example_class.C.y) |  |
+  | [z](#quartodoc.tests.example_class.C.z) |  |
+
+  ## Methods
+
+  | Name | Description |
+  | --- | --- |
+  | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
+
+  ### some_method { #quartodoc.tests.example_class.C.some_method }
+
+  `tests.example_class.C.some_method(self)`
+
+  A method
+  '''
+# ---
+# name: test_render_doc_class[flat]
+  '''
+  # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
+
+  `tests.example_class.C(self, x, y)`
+
+  The short summary.
+
+  The extended summary,
+  which may be multiple lines.
+
+  ## Parameters
+
+  | Name   | Type   | Description          | Default    |
+  |--------|--------|----------------------|------------|
+  | `x`    | str    | Uses signature type. | _required_ |
+  | `y`    | int    | Uses manual type.    | _required_ |
+
+  ## Attributes
+
+  | Name | Description |
+  | --- | --- |
+  | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
+  | [some_property](#quartodoc.tests.example_class.C.some_property) | A property |
+  | [x](#quartodoc.tests.example_class.C.x) |  |
+  | [y](#quartodoc.tests.example_class.C.y) |  |
+  | [z](#quartodoc.tests.example_class.C.z) |  |
+
+  ## Methods
+
+  | Name | Description |
+  | --- | --- |
+  | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
+
+  ## some_method { #quartodoc.tests.example_class.C.some_method }
+
+  `tests.example_class.C.some_method(self)`
+
+  A method
+  '''
+# ---
+# name: test_render_doc_class_attributes_section
+  '''
+  # quartodoc.tests.example_class.AttributesTable { #quartodoc.tests.example_class.AttributesTable }
+
+  `tests.example_class.AttributesTable(self)`
+
+  The short summary.
+
+  ## Attributes
+
+  | Name   | Type   | Description         |
+  |--------|--------|---------------------|
+  | x      | str    | Uses signature type |
+  | y      | int    | Uses manual type    |
+  | z      | float  | Defined in init     |
+  '''
+# ---
+# name: test_render_doc_module[embedded]
+  '''
+  # quartodoc.tests.example { #quartodoc.tests.example }
+
+  `tests.example`
+
+  A module
+
+  ## Attributes
+
+  | Name | Description |
+  | --- | --- |
+  | [a_attr](#quartodoc.tests.example.a_attr) | An attribute |
+
+  ## Classes
+
+  | Name | Description |
+  | --- | --- |
+  | [AClass](#quartodoc.tests.example.AClass) |  |
+
+  ## Functions
+
+  | Name | Description |
+  | --- | --- |
+  | [a_alias](#quartodoc.tests.example.a_alias) | An alias target |
+  | [a_func](#quartodoc.tests.example.a_func) | A function |
+
+  ### a_alias { #quartodoc.tests.example.a_alias }
+
+  `tests.example.a_alias()`
+
+  An alias target
+
+  ### a_func { #quartodoc.tests.example.a_func }
+
+  `tests.example.a_func()`
+
+  A function
+
+  ### AClass { #quartodoc.tests.example.AClass }
+
+  `tests.example.AClass()`
+  '''
+# ---
+# name: test_render_doc_module[flat]
+  '''
+  # quartodoc.tests.example { #quartodoc.tests.example }
+
+  `tests.example`
+
+  A module
+
+  ## Attributes
+
+  | Name | Description |
+  | --- | --- |
+  | [a_attr](#quartodoc.tests.example.a_attr) | An attribute |
+
+  ## Classes
+
+  | Name | Description |
+  | --- | --- |
+  | [AClass](#quartodoc.tests.example.AClass) |  |
+
+  ## Functions
+
+  | Name | Description |
+  | --- | --- |
+  | [a_alias](#quartodoc.tests.example.a_alias) | An alias target |
+  | [a_func](#quartodoc.tests.example.a_func) | A function |
+
+  ## a_alias { #quartodoc.tests.example.a_alias }
+
+  `tests.example.a_alias()`
+
+  An alias target
+
+  ## a_func { #quartodoc.tests.example.a_func }
+
+  `tests.example.a_func()`
+
+  A function
+
+  ## AClass { #quartodoc.tests.example.AClass }
+
+  `tests.example.AClass()`
+  '''
+# ---

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -118,6 +118,10 @@
   | --- | --- |
   | [AClass](#quartodoc.tests.example.AClass) |  |
   
+  ### AClass { #quartodoc.tests.example.AClass }
+  
+  `tests.example.AClass()`
+  
   ## Functions
   
   | Name | Description |
@@ -136,10 +140,6 @@
   `tests.example.a_func()`
   
   A function
-  
-  ### AClass { #quartodoc.tests.example.AClass }
-  
-  `tests.example.AClass()`
   '''
 # ---
 # name: test_render_doc_module[flat]
@@ -162,6 +162,10 @@
   | --- | --- |
   | [AClass](#quartodoc.tests.example.AClass) |  |
   
+  ## AClass { #quartodoc.tests.example.AClass }
+  
+  `tests.example.AClass()`
+  
   ## Functions
   
   | Name | Description |
@@ -180,9 +184,5 @@
   `tests.example.a_func()`
   
   A function
-  
-  ## AClass { #quartodoc.tests.example.AClass }
-  
-  `tests.example.AClass()`
   '''
 # ---

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -126,14 +126,7 @@
   
   | Name | Description |
   | --- | --- |
-  | [a_alias](#quartodoc.tests.example.a_alias) | An alias target |
   | [a_func](#quartodoc.tests.example.a_func) | A function |
-  
-  ### a_alias { #quartodoc.tests.example.a_alias }
-  
-  `tests.example.a_alias()`
-  
-  An alias target
   
   ### a_func { #quartodoc.tests.example.a_func }
   
@@ -170,14 +163,7 @@
   
   | Name | Description |
   | --- | --- |
-  | [a_alias](#quartodoc.tests.example.a_alias) | An alias target |
   | [a_func](#quartodoc.tests.example.a_func) | A function |
-  
-  ## a_alias { #quartodoc.tests.example.a_alias }
-  
-  `tests.example.a_alias()`
-  
-  An alias target
   
   ## a_func { #quartodoc.tests.example.a_func }
   

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -2,23 +2,23 @@
 # name: test_render_doc_class[embedded]
   '''
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
-
+  
   `tests.example_class.C(self, x, y)`
-
+  
   The short summary.
-
+  
   The extended summary,
   which may be multiple lines.
-
+  
   ## Parameters
-
+  
   | Name   | Type   | Description          | Default    |
   |--------|--------|----------------------|------------|
   | `x`    | str    | Uses signature type. | _required_ |
   | `y`    | int    | Uses manual type.    | _required_ |
-
+  
   ## Attributes
-
+  
   | Name | Description |
   | --- | --- |
   | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
@@ -26,40 +26,40 @@
   | [x](#quartodoc.tests.example_class.C.x) |  |
   | [y](#quartodoc.tests.example_class.C.y) |  |
   | [z](#quartodoc.tests.example_class.C.z) |  |
-
+  
   ## Methods
-
+  
   | Name | Description |
   | --- | --- |
   | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
-
+  
   ### some_method { #quartodoc.tests.example_class.C.some_method }
-
+  
   `tests.example_class.C.some_method(self)`
-
+  
   A method
   '''
 # ---
 # name: test_render_doc_class[flat]
   '''
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
-
+  
   `tests.example_class.C(self, x, y)`
-
+  
   The short summary.
-
+  
   The extended summary,
   which may be multiple lines.
-
+  
   ## Parameters
-
+  
   | Name   | Type   | Description          | Default    |
   |--------|--------|----------------------|------------|
   | `x`    | str    | Uses signature type. | _required_ |
   | `y`    | int    | Uses manual type.    | _required_ |
-
+  
   ## Attributes
-
+  
   | Name | Description |
   | --- | --- |
   | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
@@ -67,30 +67,30 @@
   | [x](#quartodoc.tests.example_class.C.x) |  |
   | [y](#quartodoc.tests.example_class.C.y) |  |
   | [z](#quartodoc.tests.example_class.C.z) |  |
-
+  
   ## Methods
-
+  
   | Name | Description |
   | --- | --- |
   | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
-
+  
   ## some_method { #quartodoc.tests.example_class.C.some_method }
-
+  
   `tests.example_class.C.some_method(self)`
-
+  
   A method
   '''
 # ---
 # name: test_render_doc_class_attributes_section
   '''
   # quartodoc.tests.example_class.AttributesTable { #quartodoc.tests.example_class.AttributesTable }
-
+  
   `tests.example_class.AttributesTable(self)`
-
+  
   The short summary.
-
+  
   ## Attributes
-
+  
   | Name   | Type   | Description         |
   |--------|--------|---------------------|
   | x      | str    | Uses signature type |
@@ -101,88 +101,88 @@
 # name: test_render_doc_module[embedded]
   '''
   # quartodoc.tests.example { #quartodoc.tests.example }
-
+  
   `tests.example`
-
+  
   A module
-
+  
   ## Attributes
-
+  
   | Name | Description |
   | --- | --- |
   | [a_attr](#quartodoc.tests.example.a_attr) | An attribute |
-
+  
   ## Classes
-
+  
   | Name | Description |
   | --- | --- |
   | [AClass](#quartodoc.tests.example.AClass) |  |
-
+  
   ## Functions
-
+  
   | Name | Description |
   | --- | --- |
   | [a_alias](#quartodoc.tests.example.a_alias) | An alias target |
   | [a_func](#quartodoc.tests.example.a_func) | A function |
-
+  
   ### a_alias { #quartodoc.tests.example.a_alias }
-
+  
   `tests.example.a_alias()`
-
+  
   An alias target
-
+  
   ### a_func { #quartodoc.tests.example.a_func }
-
+  
   `tests.example.a_func()`
-
+  
   A function
-
+  
   ### AClass { #quartodoc.tests.example.AClass }
-
+  
   `tests.example.AClass()`
   '''
 # ---
 # name: test_render_doc_module[flat]
   '''
   # quartodoc.tests.example { #quartodoc.tests.example }
-
+  
   `tests.example`
-
+  
   A module
-
+  
   ## Attributes
-
+  
   | Name | Description |
   | --- | --- |
   | [a_attr](#quartodoc.tests.example.a_attr) | An attribute |
-
+  
   ## Classes
-
+  
   | Name | Description |
   | --- | --- |
   | [AClass](#quartodoc.tests.example.AClass) |  |
-
+  
   ## Functions
-
+  
   | Name | Description |
   | --- | --- |
   | [a_alias](#quartodoc.tests.example.a_alias) | An alias target |
   | [a_func](#quartodoc.tests.example.a_func) | A function |
-
+  
   ## a_alias { #quartodoc.tests.example.a_alias }
-
+  
   `tests.example.a_alias()`
-
+  
   An alias target
-
+  
   ## a_func { #quartodoc.tests.example.a_func }
-
+  
   `tests.example.a_func()`
-
+  
   A function
-
+  
   ## AClass { #quartodoc.tests.example.AClass }
-
+  
   `tests.example.AClass()`
   '''
 # ---

--- a/quartodoc/tests/example_class.py
+++ b/quartodoc/tests/example_class.py
@@ -1,0 +1,50 @@
+class C:
+    """The short summary.
+
+    The extended summary,
+    which may be multiple lines.
+
+    Parameters
+    ----------
+    x:
+        Uses signature type.
+    y: int
+        Uses manual type.
+
+    """
+
+    SOME_ATTRIBUTE: float
+    """An attribute"""
+
+    def __init__(self, x: str, y: int):
+        self.x = x
+        self.y = y
+        self.z: int = 1
+
+    def some_method(self):
+        """A method"""
+
+    @property
+    def some_property(self):
+        """A property"""
+
+
+class AttributesTable:
+    """The short summary.
+
+    Attributes
+    ----------
+    x:
+        Uses signature type
+    y: int
+        Uses manual type
+    z:
+        Defined in init
+    """
+
+    x: str
+    y: int
+    """This docstring should not be used"""
+
+    def __init__(self):
+        self.z: float = 1

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -106,3 +106,14 @@ def test_blueprint_lookup_error_message(bp):
         "Does an object with the path quartodoc.bbb.ccc exist?"
         in exc_info.value.args[0]
     )
+
+
+def test_blueprint_auto_package(bp):
+    layout = blueprint(lo.Layout(package="quartodoc.tests.example"))
+    sections = layout.sections
+    assert len(sections) == 1
+    assert sections[0].title == "quartodoc.tests.example"
+    assert sections[0].desc == "A module"
+
+    # 4 objects documented
+    assert len(sections[0].contents) == 4

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -3,7 +3,7 @@ import griffe.docstrings.dataclasses as ds
 import griffe.expressions as exp
 
 from quartodoc.renderers import MdRenderer
-from quartodoc import get_object
+from quartodoc import Auto, blueprint, get_object
 
 
 @pytest.fixture
@@ -65,13 +65,35 @@ def test_render_table_description_interlink(renderer, pair):
 
 def test_render_doc_attribute(renderer):
     attr = ds.DocstringAttribute(
-        name = "abc",
+        name="abc",
         description="xyz",
         annotation=exp.Expression(exp.Name("Optional", full="Optional"), "[", "]"),
-        value=1
+        value=1,
     )
 
     res = renderer.render(attr)
 
-    assert res == ["abc", "Optional\[\]", "xyz"]
+    assert res == ["abc", r"Optional\[\]", "xyz"]
 
+
+@pytest.mark.parametrize("children", ["embedded", "flat"])
+def test_render_doc_module(snapshot, renderer, children):
+    bp = blueprint(Auto(name="quartodoc.tests.example", children=children))
+    res = renderer.render(bp)
+
+    assert res == snapshot
+
+
+@pytest.mark.parametrize("children", ["embedded", "flat"])
+def test_render_doc_class(snapshot, renderer, children):
+    bp = blueprint(Auto(name="quartodoc.tests.example_class.C", children=children))
+    res = renderer.render(bp)
+
+    assert res == snapshot
+
+
+def test_render_doc_class_attributes_section(snapshot, renderer):
+    bp = blueprint(Auto(name="quartodoc.tests.example_class.AttributesTable"))
+    res = renderer.render(bp)
+
+    assert res == snapshot

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ dev =
     pytest
     jupyterlab
     jupytext
+    syrupy
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This PR addresses #158, by autogenerating site content, when no `sections:` are specified.

For example, this config...

```
quartodoc:
  package: quartodoc
```

Will cause `quartodoc build` to produce a basic website, based on the top-level quartodoc module, with this message:

```
Autogenerating contents (since no contents specified in config)
Use the following configuration to recreate the automatically generated site:


package: quartodoc
sections:
- contents:
  - name: get_function
  - name: get_object
  - name: Builder
  - name: MdRenderer
  - name: convert_inventory
  - name: create_inventory
  - name: preview
  - name: blueprint
  - name: collect
  - name: Auto
  desc: quartodoc is a package for building delightful python API documentation.
  title: quartodoc
```

edit:

It also addresses https://github.com/machow/quartodoc/issues/197, by implementing class documentation inside modules.