### PR TITLE
Feat undoc empty

### DIFF
--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -292,6 +292,9 @@ class BlueprintTransformer(PydanticTransformer):
         if not el.include_imports:
             options = {k: v for k, v in options.items() if not v.is_alias}
 
+        if not el.include_empty:
+            options = {k: v for k, v in options.items() if v.docstring is not None}
+
         # for modules, remove any Alias objects, since they were imported from
         # other places. Sphinx has a flag for this behavior, so may be good
         # to do something similar.

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -198,6 +198,8 @@ class Auto(_Base):
         Whether to include members starting with "_"
     include_imports:
         Whether to include members that were imported from somewhere else.
+    include_empty:
+        Whether to include members with no docstring.
     include:
         (Not implemented). A list of members to include.
     exclude:
@@ -219,6 +221,7 @@ class Auto(_Base):
     members: Optional[list[str]] = None
     include_private: bool = False
     include_imports: bool = False
+    include_empty: bool = False
     include: Optional[str] = None
     exclude: Optional[str] = None
     dynamic: Union[None, bool, str] = None

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -23,9 +23,7 @@
   | --- | --- |
   | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
   | [some_property](#quartodoc.tests.example_class.C.some_property) | A property |
-  | [x](#quartodoc.tests.example_class.C.x) |  |
-  | [y](#quartodoc.tests.example_class.C.y) |  |
-  | [z](#quartodoc.tests.example_class.C.z) |  |
+  | [z](#quartodoc.tests.example_class.C.z) | A documented init attribute |
   
   ## Methods
   
@@ -64,9 +62,7 @@
   | --- | --- |
   | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
   | [some_property](#quartodoc.tests.example_class.C.some_property) | A property |
-  | [x](#quartodoc.tests.example_class.C.x) |  |
-  | [y](#quartodoc.tests.example_class.C.y) |  |
-  | [z](#quartodoc.tests.example_class.C.z) |  |
+  | [z](#quartodoc.tests.example_class.C.z) | A documented init attribute |
   
   ## Methods
   
@@ -116,11 +112,13 @@
   
   | Name | Description |
   | --- | --- |
-  | [AClass](#quartodoc.tests.example.AClass) |  |
+  | [AClass](#quartodoc.tests.example.AClass) | A class |
   
   ### AClass { #quartodoc.tests.example.AClass }
   
   `tests.example.AClass()`
+  
+  A class
   
   #### Attributes
   
@@ -171,11 +169,13 @@
   
   | Name | Description |
   | --- | --- |
-  | [AClass](#quartodoc.tests.example.AClass) |  |
+  | [AClass](#quartodoc.tests.example.AClass) | A class |
   
   ## AClass { #quartodoc.tests.example.AClass }
   
   `tests.example.AClass()`
+  
+  A class
   
   ### Attributes
   

--- a/quartodoc/tests/example.py
+++ b/quartodoc/tests/example.py
@@ -14,6 +14,8 @@ a_attr = 1
 
 
 class AClass:
+    """A class"""
+
     a_attr = 1
     """A class attribute"""
 

--- a/quartodoc/tests/example_class.py
+++ b/quartodoc/tests/example_class.py
@@ -20,6 +20,7 @@ class C:
         self.x = x
         self.y = y
         self.z: int = 1
+        """A documented init attribute"""
 
     def some_method(self):
         """A method"""


### PR DESCRIPTION
This PR adds the option `include_empty` to Auto, which specifies whether to include members with no docstring. It defaults to False, so members with empty docstrings are excluded.