### PR TITLE
Fix dynamic load

### DIFF
--- a/quartodoc/tests/example_dynamic.py
+++ b/quartodoc/tests/example_dynamic.py
@@ -29,6 +29,8 @@ class AClass:
 
 
 class InstanceAttrs:
+    """Some InstanceAttrs class"""
+
     z: int
     """The z attribute"""
 
@@ -36,3 +38,7 @@ class InstanceAttrs:
         self.a = a
         self.b = b
         """The b attribute"""
+
+
+some_instance = InstanceAttrs(1, 1)
+some_instance.__doc__ = "Dynamic instance doc"

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -79,7 +79,7 @@ def test_get_object_dynamic_class_method_doc():
     assert meth.docstring.value == "A dynamic method"
 
 
-def test_get_object_dynamic_class_method_doc():
+def test_get_object_dynamic_class_method_doc_partial():
     obj = get_object("quartodoc.tests.example_dynamic:AClass", dynamic=True)
 
     meth = obj.members["dynamic_create"]
@@ -92,7 +92,28 @@ def test_get_object_dynamic_class_instance_attr_doc():
     assert obj.members["b"].docstring.value == "The b attribute"
 
 
-def test_get_object_dynamic_class_instance_attr_doc():
+def test_get_object_dynamic_class_instance_attr_doc_class_attr_valueless():
     obj = get_object("quartodoc.tests.example_dynamic:InstanceAttrs", dynamic=True)
 
     assert obj.members["z"].docstring.value == "The z attribute"
+
+
+def test_get_object_dynamic_module_attr_str():
+    # a key behavior here is that it does not error attempting to look up
+    # str.__module__, which does not exist
+    obj = get_object("quartodoc.tests.example_dynamic:NOTE", dynamic=True)
+
+    assert obj.name == "NOTE"
+
+    # this case is weird, but we are dynamically looking up a string
+    # so our __doc__ is technically str.__doc__
+    assert obj.docstring.value == str.__doc__
+
+
+def test_get_object_dynamic_module_attr_class_instance():
+    # a key behavior here is that it does not error attempting to look up
+    # str.__module__, which does not exist
+    obj = get_object("quartodoc.tests.example_dynamic:some_instance", dynamic=True)
+
+    assert obj.path == "quartodoc.tests.example_dynamic.some_instance"
+    assert obj.docstring.value == "Dynamic instance doc"


### PR DESCRIPTION
This PR addresses https://github.com/machow/plotnine-docs-demo/issues/18. Basically, when a user uses dynamic loading, we try to infer the canonical path to the object, using the object's `__module__` attribute (if it has one). This often works for classes and functions, but for values, or instances, generally does not do what you want.

This PR bails out of this behavior if the object isn't a class or function.

Note that sphinx's `automodule`, `autofunction`, `autoattribute` provides users with helpful levers around this behavior, since you wouldn't expect `autoattribute` to even attempt this. Because we just use Auto, we are currently stuck trying to infer the right behavior from the object itself.