### PR TITLE
dev: use upper bound for griffe version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,14 @@ classifiers = [
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "click",
-    "griffe==0.25.0",
+    "griffe <= 0.32.3",
     "sphobjinv >= 2.3.1",
     "tabulate >= 0.9.0",
     "importlib-metadata >= 5.1.0",


### PR DESCRIPTION
Replace exact version pin with an upper bound (until we work out backwards compat for griffe.expression changes)