### PR TITLE
Doc builder parser arg

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -391,6 +391,9 @@ class Builder:
     dynamic:
         Whether to dynamically load all python objects. By default, objects are
         loaded using static analysis.
+    parser:
+        Docstring parser to use. This correspond to different docstring styles,
+        and can be one of "google", "sphinx", and "numpy". Defaults to "numpy".
 
     """
 

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -114,8 +114,10 @@ class MdRenderer(Renderer):
 
         """
 
-        if isinstance(el, (type(None), str)):
+        if isinstance(el, type(None)):
             return el
+        elif isinstance(el, str):
+            return sanitize(el)
 
         # TODO: maybe there is a way to get tabulate to handle this?
         # unescaped pipes screw up table formatting

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -208,3 +208,51 @@
   A function
   '''
 # ---
+# name: test_render_docstring_styles[google]
+  '''
+  # f_google { #quartodoc.tests.example_docstring_styles.f_google }
+  
+  `tests.example_docstring_styles.f_google(a, b)`
+  
+  A google style docstring.
+  
+  ## Parameters
+  
+  | Name   | Type   | Description      | Default    |
+  |--------|--------|------------------|------------|
+  | `a`    | int    | The a parameter. | _required_ |
+  | `b`    | str    | The b parameter. | _required_ |
+  '''
+# ---
+# name: test_render_docstring_styles[numpy]
+  '''
+  # f_numpy { #quartodoc.tests.example_docstring_styles.f_numpy }
+  
+  `tests.example_docstring_styles.f_numpy(a, b)`
+  
+  A numpy style docstring.
+  
+  ## Parameters
+  
+  | Name   | Type   | Description      | Default    |
+  |--------|--------|------------------|------------|
+  | `a`    |        | The a parameter. | _required_ |
+  | `b`    | str    | The b parameter. | _required_ |
+  '''
+# ---
+# name: test_render_docstring_styles[sphinx]
+  '''
+  # f_sphinx { #quartodoc.tests.example_docstring_styles.f_sphinx }
+  
+  `tests.example_docstring_styles.f_sphinx(a, b)`
+  
+  A sphinx style docstring.
+  
+  ## Parameters
+  
+  | Name   | Type   | Description      | Default    |
+  |--------|--------|------------------|------------|
+  | `a`    | int    | The a parameter. | _required_ |
+  | `b`    | str    | The b parameter. | _required_ |
+  '''
+# ---

--- a/quartodoc/tests/example_docstring_styles.py
+++ b/quartodoc/tests/example_docstring_styles.py
@@ -1,0 +1,29 @@
+def f_google(a, b: str):
+    """A google style docstring.
+
+    Args:
+        a (int): The a parameter.
+        b: The b parameter.
+    """
+
+
+def f_sphinx(a, b: str):
+    """A sphinx style docstring.
+
+    :param a: The a parameter.
+    :type a: int
+    :param b: The b parameter.
+    """
+
+
+def f_numpy(a, b: str):
+    """A numpy style docstring.
+
+    Parameters
+    ----------
+    a: int
+        The a parameter.
+    b:
+        The b parameter.
+
+    """

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -124,3 +124,14 @@ def test_render_doc_class_attributes_section(snapshot, renderer):
     res = renderer.render(bp)
 
     assert res == snapshot
+
+
+@pytest.mark.parametrize("parser", ["google", "numpy", "sphinx"])
+def test_render_docstring_styles(snapshot, renderer, parser):
+    package = "quartodoc.tests.example_docstring_styles"
+    auto = Auto(name=f"f_{parser}", package=package)
+    bp = blueprint(auto, parser=parser)
+
+    res = renderer.render(bp)
+
+    assert res == snapshot


### PR DESCRIPTION
Addresses https://github.com/machow/quartodoc/issues/241 by documenting the Builder's "parser" option, and adding basic snapshot tests of the 3 docstring styles.