### PR TITLE
Feat interlinks fast

### DIFF
--- a/_extensions/interlinks/_extension.yml
+++ b/_extensions/interlinks/_extension.yml
@@ -1,6 +1,6 @@
 title: Interlinks
 author: Michael Chow
-version: 1.0.0
+version: 1.1.0
 quarto-required: ">=1.2.0"
 contributes:
   filters:

--- a/docs/get-started/interlinks.qmd
+++ b/docs/get-started/interlinks.qmd
@@ -54,6 +54,22 @@ Notice 2 important pieces in this config:
 By default, downloaded inventory files will be saved in the `_inv` folder of your
 documentation directory.
 
+### Experimental fast option
+
+Use the experimental `fast: true` option to speed up the interlinks filter.
+
+```yaml
+interlinks:
+  fast: true
+  sources:
+```
+
+By default inventory files are saved as JSON, but this option keeps them as text files,
+and attempts to parse them much faster.
+
+:::{.callout-warning}
+Be sure to install the latest version of the interlinks filter, using `quarto add machow/quartodoc`.
+:::
 
 ## Running the interlinks filter
 

--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -220,7 +220,7 @@ def interlinks(config, dry_run, fast):
 
     p_root = Path(config).parent
 
-    if interlinks is None:
+    if not interlinks:
         print("No interlinks field found in your quarto config. Quitting.")
         return
 

--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -218,6 +218,9 @@ def interlinks(config, dry_run, fast):
     interlinks = cfg.get("interlinks", None)
 
     cache = cfg.get("cache", "_inv")
+    cfg_fast = cfg.get("fast", False)
+
+    fast = cfg_fast or fast
 
     p_root = Path(config).parent
 

--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -214,19 +214,21 @@ def build(config, filter, dry_run, watch, verbose):
 @click.option("--dry-run", is_flag=True, default=False)
 @click.option("--fast", is_flag=True, default=False)
 def interlinks(config, dry_run, fast):
+    # config loading ----
     cfg = yaml.safe_load(open(config))
-    interlinks = cfg.get("interlinks", None)
-
-    cache = cfg.get("cache", "_inv")
-    cfg_fast = cfg.get("fast", False)
-
-    fast = cfg_fast or fast
+    interlinks = cfg.get("interlinks", {})
 
     p_root = Path(config).parent
 
     if interlinks is None:
         print("No interlinks field found in your quarto config. Quitting.")
         return
+
+    # interlinks config settings ----
+    cache = interlinks.get("cache", "_inv")
+    cfg_fast = interlinks.get("fast", False)
+
+    fast = cfg_fast or fast
 
     for k, v in interlinks["sources"].items():
         # don't include user's own docs (users don't need to specify their own docs in

--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -225,7 +225,7 @@ def interlinks(config, dry_run, fast):
         return
 
     # interlinks config settings ----
-    cache = interlinks.get("cache", "_inv")
+    cache = p_root / "_inv"
     cfg_fast = interlinks.get("fast", False)
 
     fast = cfg_fast or fast

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -656,7 +656,7 @@ class Builder:
         style = cfg.get("style", "pkgdown")
         cls_builder = cls._registry[style]
 
-        _fast_inventory = cfg.get("interlinks", {}).get("fast", False)
+        _fast_inventory = quarto_cfg.get("interlinks", {}).get("fast", False)
 
         return cls_builder(
             **{k: v for k, v in cfg.items() if k != "style"},


### PR DESCRIPTION
This PR addresses #249 , by adding a "fast" mode via the `quartodoc interlinks --fast` command.

* this command generates inventory files as plain text (e.g. objects_python.txt) rather than json
* when it detects a `.txt` file, the lua filter will parse that using regexes inspired by https://github.com/bskinn/sphobjinv/blob/main/src/sphobjinv/re.py

This should cut parse time to about 1/5th what it was. Note that the package being generated still produces a json inventory. I think we eventually should swap that out with json (and move it into `_inv`, and later the `.quartodoc` scratchpad folder).