### PR TITLE
feat(interlinks): filter on py domain by default

### DIFF
--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -31,7 +31,7 @@ local function lookup(search_object)
             if search_object.domain and item.domain ~= search_object.domain then
                 goto continue
             else
-                if item.domain == "py" then
+                if search_object.domain or item.domain == "py" then
                   table.insert(results, item)
                 end
 

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -10,11 +10,11 @@ end
 
 local inventory = {}
 
-function lookup(search_object)
+local function lookup(search_object)
 
     local results = {}
-    for ii, inventory in ipairs(inventory) do
-        for jj, item in ipairs(inventory.items) do
+    for _, inv in ipairs(inventory) do
+        for _, item in ipairs(inv.items) do
             -- e.g. :external+<inv_name>:<domain>:<role>:`<name>`
             if item.inv_name and item.inv_name ~= search_object.inv_name then
                 goto continue
@@ -44,19 +44,18 @@ function lookup(search_object)
         return results[1]
     end
     if #results > 1 then
-        print("Found multiple matches for " .. search_object.name)
-        quarto.utils.dump(results)
-        return nil
+        quarto.log.warning("Found multiple matches for " .. search_object.name .. ", using the first match.")
+        return results[1]
     end
     if #results == 0 then
-        print("Found no matches for object:")
-        quarto.utils.dump(search_object)
+        quarto.log.warning("Found no matches for object: " .. search_object.name .. ".")
+        quarto.log.dump(search_object)
     end
 
     return nil
 end
 
-function mysplit (inputstr, sep)
+local function mysplit (inputstr, sep)
     if sep == nil then
             sep = "%s"
     end
@@ -97,7 +96,7 @@ local function build_search_object(str)
             search.role = normalize_role(t[3])
             search.name = t[4]:match("%%60(.*)%%60")
         else
-            print("couldn't parse this link: " .. str)
+            quarto.log.warning("couldn't parse this link: " .. str)
             return {}
         end
     else
@@ -105,7 +104,7 @@ local function build_search_object(str)
     end
 
     if search.name == nil then
-        print("couldn't parse this link: " .. str)
+        quarto.log.warning("couldn't parse this link: " .. str)
         return {}
     end
 
@@ -116,7 +115,7 @@ local function build_search_object(str)
     return search
 end
 
-function report_broken_link(link, search_object, replacement)
+local function report_broken_link(link, search_object, replacement)
     -- TODO: how to unescape html elements like [?
     return pandoc.Code(pandoc.utils.stringify(link.content))
 end
@@ -154,7 +153,7 @@ function Link(link)
     return link
 end
 
-function fixup_json(json, prefix)
+local function fixup_json(json, prefix)
     for _, item in ipairs(json.items) do
         item.uri = prefix .. item.uri
     end

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -31,7 +31,9 @@ local function lookup(search_object)
             if search_object.domain and item.domain ~= search_object.domain then
                 goto continue
             else
-                table.insert(results, item)
+                if item.domain == "py" then
+                  table.insert(results, item)
+                end
 
                 goto continue
             end

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -50,8 +50,7 @@ local function lookup(search_object)
         return results[1]
     end
     if #results == 0 then
-        quarto.log.warning("Found no matches for object: " .. search_object.name .. ".")
-        quarto.log.dump(search_object)
+        quarto.log.warning("Found no matches for object:\n", search_object)
     end
 
     return nil


### PR DESCRIPTION
Types such as `dict` and `list` in the python standard library appear multiple times in the inventory. For example, for `dict`, there is the standard library https://docs.python.org/3.10/library/stdtypes.html#dict (the one we want), but also more obscure matches like https://docs.python.org/3.10/library/2to3.html?highlight=dict#to3fixer-dict.

Luckily, the `stdtypes` matches come up first. There is no guaranty for this, but I think it is fine to still link the first match and log a warning instead of not linking them.

While I was at it, I also made the module local functions local, renamed the `inventory` variable in the for loop to not shadow the global `inventory` and replaced deprecated `quarto.utils` functions with the appropriate `quarto.log` functions (had to get rid of those squiggly lines).