### PR TITLE
feat: allow single  blank line in numpydoc parameter docstrings

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 
 from .inventory import create_inventory, convert_inventory
 from . import layout
+from .parsers import get_parser_defaults
 from .renderers import Renderer
 from .validation import fmt
 
@@ -59,7 +60,9 @@ def get_function(module: str, func_name: str, parser: str = "numpy") -> dc.Objec
     <Function('get_function', ...
 
     """
-    griffe = GriffeLoader(docstring_parser=Parser(parser))
+    griffe = GriffeLoader(
+        docstring_parser=Parser(parser), docstring_options=get_parser_defaults(parser)
+    )
     mod = griffe.load_module(module)
 
     f_data = mod.functions[func_name]
@@ -118,6 +121,7 @@ def get_object(
     if loader is None:
         loader = GriffeLoader(
             docstring_parser=Parser(parser),
+            docstring_options=get_parser_defaults(parser),
             modules_collection=ModulesCollection(),
             lines_collection=LinesCollection(),
         )

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -25,6 +25,7 @@ from quartodoc.layout import (
     Page,
     Section,
 )
+from quartodoc.parsers import get_parser_defaults
 from quartodoc import get_object as _get_object
 
 from .utils import PydanticTransformer, ctx_node, WorkaroundKeyError
@@ -131,6 +132,7 @@ class BlueprintTransformer(PydanticTransformer):
         if get_object is None:
             loader = GriffeLoader(
                 docstring_parser=Parser(parser),
+                docstring_options=get_parser_defaults(parser),
                 modules_collection=ModulesCollection(),
                 lines_collection=LinesCollection(),
             )

--- a/quartodoc/parsers.py
+++ b/quartodoc/parsers.py
@@ -1,0 +1,9 @@
+DEFAULT_OPTIONS = {
+    "numpy": {
+        "allow_section_blank_line": True,
+    }
+}
+
+
+def get_parser_defaults(name: str):
+    return DEFAULT_OPTIONS.get(name, {})

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -208,6 +208,22 @@
   A function
   '''
 # ---
+# name: test_render_docstring_numpy_linebreaks
+  '''
+  # f_numpy_with_linebreaks { #quartodoc.tests.example_docstring_styles.f_numpy_with_linebreaks }
+  
+  `tests.example_docstring_styles.f_numpy_with_linebreaks(a, b)`
+  
+  A numpy style docstring.
+  
+  ## Parameters
+  
+  | Name   | Type   | Description      | Default    |
+  |--------|--------|------------------|------------|
+  | `a`    |        | The a parameter. | _required_ |
+  | `b`    | str    | The b parameter. | _required_ |
+  '''
+# ---
 # name: test_render_docstring_styles[google]
   '''
   # f_google { #quartodoc.tests.example_docstring_styles.f_google }

--- a/quartodoc/tests/example_docstring_styles.py
+++ b/quartodoc/tests/example_docstring_styles.py
@@ -27,3 +27,19 @@ def f_numpy(a, b: str):
         The b parameter.
 
     """
+
+
+# we set an option by default in griffe's numpy parsing
+# to allow linebreaks in parameter tables
+def f_numpy_with_linebreaks(a, b: str):
+    """A numpy style docstring.
+
+    Parameters
+    ----------
+    a: int
+        The a parameter.
+
+    b:
+        The b parameter.
+
+    """

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -135,3 +135,13 @@ def test_render_docstring_styles(snapshot, renderer, parser):
     res = renderer.render(bp)
 
     assert res == snapshot
+
+
+def test_render_docstring_numpy_linebreaks(snapshot, renderer):
+    package = "quartodoc.tests.example_docstring_styles"
+    auto = Auto(name="f_numpy_with_linebreaks", package=package)
+    bp = blueprint(auto)
+
+    res = renderer.render(bp)
+
+    assert res == snapshot


### PR DESCRIPTION
Addresses #248, by setting default `docstring_options` in the griffe loader.