### PR TITLE
feat: add Auto signature_path and member_options fields

### DIFF
--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -116,15 +116,10 @@ def _to_simple_dict(el: "BaseModel"):
     return json.loads(el.json(exclude_unset=True))
 
 
-def _non_default_entries(el: "BaseModel"):
-    field_defaults = {mf.name: mf.default for mf in el.__fields__.values()}
-    set_fields = [
-        k for k, v in el if field_defaults[k] is not v if not isinstance(v, MISSING)
-    ]
-
+def _non_default_entries(el: Auto):
     d = el.dict()
 
-    return {k: d[k] for k in set_fields}
+    return {k: d[k] for k in el._fields_specified}
 
 
 class BlueprintTransformer(PydanticTransformer):
@@ -280,6 +275,12 @@ class BlueprintTransformer(PydanticTransformer):
 
         # Three cases for structuring child methods ----
 
+        _defaults = {"dynamic": dynamic, "package": path}
+        if el.member_options is not None:
+            member_options = {**_defaults, **_non_default_entries(el.member_options)}
+        else:
+            member_options = _defaults
+
         children = []
         for entry in raw_members:
             # Note that we could have iterated over obj.members, but currently
@@ -293,7 +294,7 @@ class BlueprintTransformer(PydanticTransformer):
             # create Doc element for member ----
             # TODO: when a member is a Class, it is currently created using
             # defaults, and there is no way to override those.
-            doc = self.visit(Auto(name=relative_path, dynamic=dynamic, package=path))
+            doc = self.visit(Auto(name=relative_path, **member_options))
 
             # do no document submodules
             if (
@@ -325,7 +326,9 @@ class BlueprintTransformer(PydanticTransformer):
             children.append(res)
 
         is_flat = el.children == ChoicesChildren.flat
-        return Doc.from_griffe(el.name, obj, members=children, flat=is_flat)
+        return Doc.from_griffe(
+            el.name, obj, children, flat=is_flat, signature_path=el.signature_path
+        )
 
     @staticmethod
     def _fetch_members(el: Auto, obj: dc.Object | dc.Alias):

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -327,7 +327,11 @@ class BlueprintTransformer(PydanticTransformer):
 
         is_flat = el.children == ChoicesChildren.flat
         return Doc.from_griffe(
-            el.name, obj, children, flat=is_flat, signature_path=el.signature_path
+            el.name,
+            obj,
+            children,
+            flat=is_flat,
+            signature_name=el.signature_name,
         )
 
     @staticmethod

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -207,7 +207,7 @@ SignatureOptions = Literal["full", "short", "relative"]
 class AutoOptions(_Base):
     """Options available for Auto content layout element."""
 
-    signature_path: SignatureOptions = "relative"
+    signature_name: SignatureOptions = "relative"
     members: Optional[list[str]] = None
     include_private: bool = False
     include_imports: bool = False
@@ -335,7 +335,7 @@ class Doc(_Docable):
     name: str
     obj: Union[dc.Object, dc.Alias]
     anchor: str
-    signature_path: SignatureOptions = "relative"
+    signature_name: SignatureOptions = "relative"
 
     class Config:
         arbitrary_types_allowed = True
@@ -349,7 +349,7 @@ class Doc(_Docable):
         members=None,
         anchor: str = None,
         flat: bool = False,
-        signature_path: str = "relative",
+        signature_name: str = "relative",
     ):
         if members is None:
             members = []
@@ -361,7 +361,7 @@ class Doc(_Docable):
             "name": name,
             "obj": obj,
             "anchor": anchor,
-            "signature_path": signature_path,
+            "signature_name": signature_name,
         }
 
         if kind == "function":

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -137,7 +137,7 @@ class MdRenderer(Renderer):
         # TODO: this is for backwards compatibility with the old approach
         # of only defining signature over griffe objects, which projects
         # like shiny currently extend
-        self.display_name = el.signature_path
+        self.display_name = el.signature_name
         res = self.signature(el.obj)
         self.display_name = orig
 

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -232,6 +232,15 @@
   A function
   '''
 # ---
+# name: test_render_doc_signature_path
+  '''
+  # example.a_func { #quartodoc.tests.example.a_func }
+  
+  `a_func()`
+  
+  A function
+  '''
+# ---
 # name: test_render_docstring_numpy_linebreaks
   '''
   # f_numpy_with_linebreaks { #quartodoc.tests.example_docstring_styles.f_numpy_with_linebreaks }

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -232,7 +232,7 @@
   A function
   '''
 # ---
-# name: test_render_doc_signature_path
+# name: test_render_doc_signature_name
   '''
   # example.a_func { #quartodoc.tests.example.a_func }
   

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -49,10 +49,7 @@ def test_render_attribute():
     # TODO: snapshot tests
     a = get_object("quartodoc", "tests.example_attribute.a")
 
-    assert (
-        MdRenderer().render(a)
-        == "`tests.example_attribute.a`\n\nI am an attribute docstring"
-    )
+    assert MdRenderer().render(a) == "I am an attribute docstring"
 
 
 def test_get_object_dynamic_module_root():

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -87,7 +87,7 @@ def test_blueprint_default_dynamic(bp):
     assert NOTE in res.obj.docstring.value
 
 
-def test_blueprint_auto_package(bp):
+def test_blueprint_auto_anchor(bp):
     auto = lo.Auto(name="a_func", package="quartodoc.tests.example")
     res = bp.visit(auto)
 
@@ -183,3 +183,19 @@ def test_blueprint_fetch_members_include_inherited():
 
     member_names = set([entry.name for entry in bp.members])
     assert "some_method" in member_names
+
+
+def test_blueprint_member_options():
+    auto = lo.Auto(
+        name="quartodoc.tests.example",
+        member_options={"signature_path": "short"},
+        members=["AClass"],
+    )
+    bp = blueprint(auto)
+    doc_a_class = bp.members[0]
+
+    # member has option set
+    assert doc_a_class.signature_path == "short"
+
+    # this currently does not apply to members of members
+    assert doc_a_class.members[0].signature_path == "relative"

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -188,14 +188,14 @@ def test_blueprint_fetch_members_include_inherited():
 def test_blueprint_member_options():
     auto = lo.Auto(
         name="quartodoc.tests.example",
-        member_options={"signature_path": "short"},
+        member_options={"signature_name": "short"},
         members=["AClass"],
     )
     bp = blueprint(auto)
     doc_a_class = bp.members[0]
 
     # member has option set
-    assert doc_a_class.signature_path == "short"
+    assert doc_a_class.signature_name == "short"
 
     # this currently does not apply to members of members
-    assert doc_a_class.members[0].signature_path == "relative"
+    assert doc_a_class.members[0].signature_name == "relative"

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -145,3 +145,13 @@ def test_render_docstring_numpy_linebreaks(snapshot, renderer):
     res = renderer.render(bp)
 
     assert res == snapshot
+
+
+def test_render_doc_signature_path(snapshot, renderer):
+    package = "quartodoc.tests"
+    auto = Auto(name="example.a_func", package=package, signature_path="short")
+    bp = blueprint(auto)
+
+    res = renderer.render(bp)
+
+    assert res == snapshot

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -147,9 +147,9 @@ def test_render_docstring_numpy_linebreaks(snapshot, renderer):
     assert res == snapshot
 
 
-def test_render_doc_signature_path(snapshot, renderer):
+def test_render_doc_signature_name(snapshot, renderer):
     package = "quartodoc.tests"
-    auto = Auto(name="example.a_func", package=package, signature_path="short")
+    auto = Auto(name="example.a_func", package=package, signature_name="short")
     bp = blueprint(auto)
 
     res = renderer.render(bp)


### PR DESCRIPTION
addresses #226 by adding two options to Auto:

* `signature_path`: whether to show the full, relative, or short name for a function.
* `member_options`: Auto options to set on members

Note that there were a number of changes necessary to enable these options:

* Because the renderer generates signatures directly from griffe objects, but we set signature_path on layout.Doc, we needed to temporarily set signature_path on the renderer, prior to rendering.
* I cleaned up how quartodoc detects options specified on Auto (in `_non_default_fields()`), so we can get back exactly the arguments a user passed to initiate auto or options.