### PR TITLE
feat: show_source config option to show source code

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -87,7 +87,8 @@ quartodoc:
         These functions fetch and analyze python objects, including parsing docstrings.
         They prepare a basic representation of your doc site that can be rendered and built.
       contents:
-        - Auto
+        - name: Auto
+          show_source: true
         - blueprint
         - collect
         - get_object

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -116,15 +116,10 @@ def _to_simple_dict(el: "BaseModel"):
     return json.loads(el.json(exclude_unset=True))
 
 
-def _non_default_entries(el: "BaseModel"):
-    field_defaults = {mf.name: mf.default for mf in el.__fields__.values()}
-    set_fields = [
-        k for k, v in el if field_defaults[k] is not v if not isinstance(v, MISSING)
-    ]
-
+def _non_default_entries(el: Auto):
     d = el.dict()
 
-    return {k: d[k] for k in set_fields}
+    return {k: d[k] for k in el._fields_specified}
 
 
 class BlueprintTransformer(PydanticTransformer):
@@ -280,6 +275,12 @@ class BlueprintTransformer(PydanticTransformer):
 
         # Three cases for structuring child methods ----
 
+        _defaults = {"dynamic": dynamic, "package": path}
+        if el.member_options is not None:
+            member_options = {**_defaults, **_non_default_entries(el.member_options)}
+        else:
+            member_options = _defaults
+
         children = []
         for entry in raw_members:
             # Note that we could have iterated over obj.members, but currently
@@ -293,7 +294,7 @@ class BlueprintTransformer(PydanticTransformer):
             # create Doc element for member ----
             # TODO: when a member is a Class, it is currently created using
             # defaults, and there is no way to override those.
-            doc = self.visit(Auto(name=relative_path, dynamic=dynamic, package=path))
+            doc = self.visit(Auto(name=relative_path, **member_options))
 
             # do no document submodules
             if (
@@ -325,7 +326,9 @@ class BlueprintTransformer(PydanticTransformer):
             children.append(res)
 
         is_flat = el.children == ChoicesChildren.flat
-        return Doc.from_griffe(el.name, obj, members=children, flat=is_flat)
+        return Doc.from_griffe(
+            el.name, obj, children, flat=is_flat, signature_path=el.signature_path
+        )
 
     @staticmethod
     def _fetch_members(el: Auto, obj: dc.Object | dc.Alias):

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -327,7 +327,12 @@ class BlueprintTransformer(PydanticTransformer):
 
         is_flat = el.children == ChoicesChildren.flat
         return Doc.from_griffe(
-            el.name, obj, children, flat=is_flat, signature_path=el.signature_path
+            el.name,
+            obj,
+            children,
+            flat=is_flat,
+            signature_path=el.signature_path,
+            show_source=el.show_source,
         )
 
     @staticmethod

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -224,6 +224,7 @@ class AutoOptions(_Base):
     exclude: Optional[str] = None
     dynamic: Union[None, bool, str] = None
     children: ChoicesChildren = ChoicesChildren.embedded
+    show_source: bool = False
     package: Union[str, None, MISSING] = MISSING()
     member_options: Optional["AutoOptions"] = None
 
@@ -270,6 +271,8 @@ class Auto(AutoOptions):
         to return an alias for that object.
     children:
         Style for presenting members. Either separate, embedded, or flat.
+    show_source:
+        Whether to show the source code for the object.
     package:
         If specified, object lookup will be relative to this path.
     member_options:
@@ -336,6 +339,7 @@ class Doc(_Docable):
     obj: Union[dc.Object, dc.Alias]
     anchor: str
     signature_path: SignatureOptions = "relative"
+    show_source: bool = False
 
     class Config:
         arbitrary_types_allowed = True
@@ -350,6 +354,7 @@ class Doc(_Docable):
         anchor: str = None,
         flat: bool = False,
         signature_path: str = "relative",
+        show_source: bool = False,
     ):
         if members is None:
             members = []
@@ -362,6 +367,7 @@ class Doc(_Docable):
             "obj": obj,
             "anchor": anchor,
             "signature_path": signature_path,
+            "show_source": show_source,
         }
 
         if kind == "function":

--- a/quartodoc/renderers/base.py
+++ b/quartodoc/renderers/base.py
@@ -1,4 +1,5 @@
 import re
+import html
 
 from plum import dispatch
 
@@ -8,6 +9,18 @@ from plum import dispatch
 
 def escape(val: str):
     return f"`{val}`"
+
+
+def escape_source(source: str):
+    """Escape python source code for adding to a qmd file.
+
+    Since quarto looks for ```{python} blocks, even in indented markdown,
+    we need to be careful to ensure it doesn't attempt to execute parts of
+    python source code (since the output will look wrong and weird).
+    """
+
+    # escape html characters, and replace ` with its html encoding
+    return html.escape(source, quote=False).replace("`", "&#96;")
 
 
 def sanitize(val: str, allow_markdown=False):

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -232,6 +232,15 @@
   A function
   '''
 # ---
+# name: test_render_doc_signature_path
+  '''
+  # example.a_func { #quartodoc.tests.example.a_func }
+  
+  `a_func()`
+  
+  A function
+  '''
+# ---
 # name: test_render_docstring_numpy_linebreaks
   '''
   # f_numpy_with_linebreaks { #quartodoc.tests.example_docstring_styles.f_numpy_with_linebreaks }

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -232,6 +232,30 @@
   A function
   '''
 # ---
+# name: test_render_doc_show_source
+  '''
+  # f_quarto_block_in_docstring { #quartodoc.tests.example_docstring_styles.f_quarto_block_in_docstring }
+  
+  `tests.example_docstring_styles.f_quarto_block_in_docstring(a, b)`
+  
+  A quarto style docstring.
+  
+  ```{python}
+  1 < 2
+  ```
+  
+  <details>
+  <summary>Show source</summary>
+  <pre><code>def f_quarto_block_in_docstring(a, b: str):
+      """A quarto style docstring.
+  
+      &#96;&#96;&#96;{python}
+      1 &lt; 2
+      &#96;&#96;&#96;
+      """</code></pre>
+  </details>
+  '''
+# ---
 # name: test_render_doc_signature_path
   '''
   # example.a_func { #quartodoc.tests.example.a_func }

--- a/quartodoc/tests/example_docstring_styles.py
+++ b/quartodoc/tests/example_docstring_styles.py
@@ -43,3 +43,12 @@ def f_numpy_with_linebreaks(a, b: str):
         The b parameter.
 
     """
+
+
+def f_quarto_block_in_docstring(a, b: str):
+    """A quarto style docstring.
+
+    ```{python}
+    1 < 2
+    ```
+    """

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -49,10 +49,7 @@ def test_render_attribute():
     # TODO: snapshot tests
     a = get_object("quartodoc", "tests.example_attribute.a")
 
-    assert (
-        MdRenderer().render(a)
-        == "`tests.example_attribute.a`\n\nI am an attribute docstring"
-    )
+    assert MdRenderer().render(a) == "I am an attribute docstring"
 
 
 def test_get_object_dynamic_module_root():

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -87,7 +87,7 @@ def test_blueprint_default_dynamic(bp):
     assert NOTE in res.obj.docstring.value
 
 
-def test_blueprint_auto_package(bp):
+def test_blueprint_auto_anchor(bp):
     auto = lo.Auto(name="a_func", package="quartodoc.tests.example")
     res = bp.visit(auto)
 
@@ -183,3 +183,19 @@ def test_blueprint_fetch_members_include_inherited():
 
     member_names = set([entry.name for entry in bp.members])
     assert "some_method" in member_names
+
+
+def test_blueprint_member_options():
+    auto = lo.Auto(
+        name="quartodoc.tests.example",
+        member_options={"signature_path": "short"},
+        members=["AClass"],
+    )
+    bp = blueprint(auto)
+    doc_a_class = bp.members[0]
+
+    # member has option set
+    assert doc_a_class.signature_path == "short"
+
+    # this currently does not apply to members of members
+    assert doc_a_class.members[0].signature_path == "relative"

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -145,3 +145,13 @@ def test_render_docstring_numpy_linebreaks(snapshot, renderer):
     res = renderer.render(bp)
 
     assert res == snapshot
+
+
+def test_render_doc_signature_path(snapshot, renderer):
+    package = "quartodoc.tests"
+    auto = Auto(name="example.a_func", package=package, signature_path="short")
+    bp = blueprint(auto)
+
+    res = renderer.render(bp)
+
+    assert res == snapshot

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -155,3 +155,25 @@ def test_render_doc_signature_path(snapshot, renderer):
     res = renderer.render(bp)
 
     assert res == snapshot
+
+
+def test_render_source(renderer):
+    obj = get_object("quartodoc.tests.example.a_func")
+    res = renderer.render_source(obj)
+
+    code = '''\
+def a_func():
+    """A function"""\
+'''
+
+    res == f"<code><pre>{code}</pre></code>"
+
+
+def test_render_doc_show_source(renderer, snapshot):
+    package = "quartodoc.tests.example_docstring_styles"
+    auto = Auto(name="f_quarto_block_in_docstring", package=package, show_source=True)
+    bp = blueprint(auto)
+
+    res = renderer.render(bp)
+
+    assert res == snapshot


### PR DESCRIPTION
This PR addresses #225 by adding an option to reveal source code for a documented object.

TODO:

- [ ] : figure out default styling