### PR TITLE
fix: setting member_options no longer unsets package on members

### DIFF
--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -117,9 +117,7 @@ def _to_simple_dict(el: "BaseModel"):
 
 
 def _non_default_entries(el: Auto):
-    d = el.dict()
-
-    return {k: d[k] for k in el._fields_specified}
+    return {k: getattr(el, k) for k in el._fields_specified}
 
 
 class BlueprintTransformer(PydanticTransformer):

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -1,6 +1,7 @@
 from quartodoc import get_object
 from quartodoc import layout as lo
 from quartodoc.builder.blueprint import (
+    _non_default_entries,
     BlueprintTransformer,
     blueprint,
     WorkaroundKeyError,
@@ -35,6 +36,23 @@ def lay():
 @pytest.fixture
 def bp():
     return BlueprintTransformer()
+
+
+def test_non_default_entries_auto():
+    assert _non_default_entries(lo.Auto(name="a_func", include_attributes=False)) == {
+        "name": "a_func",
+        "include_attributes": False,
+    }
+
+
+def test_non_default_entries_auto_member_options():
+    # these entries are nested inside auto
+    res = _non_default_entries(
+        lo.Auto(name="a_func", member_options={"include_attributes": False})
+    )
+
+    assert res["name"] == "a_func"
+    assert _non_default_entries(res["member_options"]) == {"include_attributes": False}
 
 
 @pytest.mark.parametrize("path", ["quartodoc.get_object", "quartodoc:get_object"])


### PR DESCRIPTION
This PR fixes a bug where setting member_options in options, caused package and dynamic to be set back to their default values on the members

```python
from quartodoc import blueprint, Builder

cfg = yaml.safe_load("""
quartodoc:
  package: quartodoc
  options:
    member_options:
      signature_name: "short"
  sections:
    - contents:
      - MdRenderer
"""

builder = Builder.from_quarto_cfg(cfg)
blueprint(builder)
```

Caused the error:

```python
WorkaroundKeyError: Cannot find an object named: render_header. Does an object with the path quartodoc:render_header exist?
```

Since it unset package from `quartodoc.MdRenderer`, and fell back on the default package `quartodoc` (in the top-level config).

The gist is that blueprint uses a function called `_non_default_entries` to get only the arguments manually specified options (since pydantic automatically puts in the defaults, we need a way to get only the ones users manually specified). However, because `member_options` are nested inside `Auto`, and we were converting the pydantic Auto to a dict, we accidentally grabbed the defaults too there.