### PR TITLE
Update devcontainer config

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,14 +1,19 @@
 {
-    "build": { "dockerfile": "Dockerfile" },
-  
-    "customizations": {
-      "vscode": {
-        "extensions": [
-            "quarto.quarto",
-            "ms-python.python"
-          ]
-      }
-    },
-  
-    "forwardPorts": [8888]
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "features": {
+    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
+      "version": "prerelease"
+    }
+  },
+  "forwardPorts": [
+    8888
+  ],
+  "portsAttributes": {
+    "8888": {
+      "label": "Jupyter"
+    }
+  },
+  "onCreateCommand": {
+    "prep-python": "python3 -m pip install --upgrade setuptools jupyterlab ipython jupyterlab-quarto -e '.[dev]'"
   }
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -13,6 +13,12 @@
       "label": "Jupyter"
     }
   },
+  "vscode": {
+    "extensions": [
+      "ms-toolsai.jupyter",
+      "ms-python.python"
+    ]
+  },
   "onCreateCommand": {
     "prep-python": "python3 -m pip install --upgrade setuptools jupyterlab ipython jupyterlab-quarto -e '.[dev]'"
   }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM ghcr.io/quarto-dev/quarto:1.4.330
-
-RUN apt-get update && apt-get install -y python3 python3-pip git
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools jupyterlab ipython jupyterlab-quarto
-COPY ./ /quartodoc
-WORKDIR /quartodoc
-RUN pip3 install -e ".[dev]"


### PR DESCRIPTION
Addresses #251, replaces #252

Modify the following aspects of the previous container:

- Only had the root user in the container, causing permission issues when run locally.
- The version of Quarto CLI was hard coded and the new version could not be installed without updating the file.
- Arm64 support lacks.
- Dockerfile had to be included in the repository.