### PR TITLE
Fix no render self

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -99,6 +99,14 @@ class MdRenderer(Renderer):
             return el.canonical_path
 
         raise ValueError(f"Unsupported display_name: `{self.display_name}`")
+    
+    def _fetch_method_parameters(self, el: dc.Function):
+        # adapted from mkdocstrings-python jinja tempalate
+        if el.parent and el.parent.is_class and len(el.parameters) > 0:
+            if el.parameters[0].name in {"self", "cls"}:
+                return dc.Parameters(*list(el.parameters)[1:])
+        
+        return el.parameters
 
     def _render_table(self, rows, headers):
         table = tabulate(rows, headers=headers, tablefmt="github")
@@ -162,7 +170,7 @@ class MdRenderer(Renderer):
         self, el: Union[dc.Class, dc.Function], source: Optional[dc.Alias] = None
     ):
         name = self._fetch_object_dispname(source or el)
-        pars = self.render(el.parameters)
+        pars = self.render(self._fetch_method_parameters(el))
 
         return f"`{name}({pars})`"
 

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -54,7 +54,14 @@
   
   | Name | Description |
   | --- | --- |
+  | [some_class_method](#quartodoc.tests.example_class.C.some_class_method) | A class method |
   | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
+  
+  ### some_class_method { #quartodoc.tests.example_class.C.some_class_method }
+  
+  `tests.example_class.C.some_class_method()`
+  
+  A class method
   
   ### some_method { #quartodoc.tests.example_class.C.some_method }
   
@@ -105,7 +112,14 @@
   
   | Name | Description |
   | --- | --- |
+  | [some_class_method](#quartodoc.tests.example_class.C.some_class_method) | A class method |
   | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
+  
+  ## some_class_method { #quartodoc.tests.example_class.C.some_class_method }
+  
+  `tests.example_class.C.some_class_method()`
+  
+  A class method
   
   ## some_method { #quartodoc.tests.example_class.C.some_method }
   

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -58,7 +58,7 @@
   
   ### some_method { #quartodoc.tests.example_class.C.some_method }
   
-  `tests.example_class.C.some_method(self)`
+  `tests.example_class.C.some_method()`
   
   A method
   '''
@@ -109,7 +109,7 @@
   
   ## some_method { #quartodoc.tests.example_class.C.some_method }
   
-  `tests.example_class.C.some_method(self)`
+  `tests.example_class.C.some_method()`
   
   A method
   '''

--- a/quartodoc/tests/example_class.py
+++ b/quartodoc/tests/example_class.py
@@ -29,6 +29,10 @@ class C:
     def some_property(self):
         """A property"""
 
+    @classmethod
+    def some_class_method(cls):
+        """A class method"""
+
     class D:
         """A nested class"""
 

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -183,12 +183,19 @@ def _check_member_names(members, expected):
     [
         ("attributes", {"some_property", "z", "SOME_ATTRIBUTE"}),
         ("classes", {"D"}),
-        ("functions", {"some_method"}),
+        ("functions", {"some_method", "some_class_method"}),
     ],
 )
 def test_blueprint_fetch_members_include_kind_false(kind, removed):
     option = {f"include_{kind}": False}
-    all_members = {"SOME_ATTRIBUTE", "z", "some_property", "some_method", "D"}
+    all_members = {
+        "SOME_ATTRIBUTE",
+        "z",
+        "some_property",
+        "some_method",
+        "D",
+        "some_class_method",
+    }
 
     auto = lo.Auto(name="quartodoc.tests.example_class.C", **option)
     bp = blueprint(auto)


### PR DESCRIPTION
Addresses #270, by removing parameters named "self" or "cls" from function signatures, when...

* the functions are on a class
* the matching parameter is the first one in the signature