### PR TITLE
fix(interlinks): do not error if no config found

### DIFF
--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -232,12 +232,14 @@ return {
         Meta = function(meta)
             local json
             local prefix
-            for k, v in pairs(meta.interlinks.sources) do
-                local base_name = quarto.project.offset .. "/_inv/" .. k .. "_objects"
-                json = read_inv_text_or_json(base_name)
-                prefix = pandoc.utils.stringify(v.url)
-                if json ~= nil then
-                    fixup_json(json, prefix)
+            if meta.interlinks and meta.interlinks.sources then
+                for k, v in pairs(meta.interlinks.sources) do
+                    local base_name = quarto.project.offset .. "/_inv/" .. k .. "_objects"
+                    json = read_inv_text_or_json(base_name)
+                    prefix = pandoc.utils.stringify(v.url)
+                    if json ~= nil then
+                        fixup_json(json, prefix)
+                    end
                 end
             end
             json = read_inv_text_or_json(quarto.project.offset .. "/objects")


### PR DESCRIPTION
This PR ensures that the filter does not produce an error under these conditions:

* a user adds the interlinks filter, but
* does not have an `interlinks:` config in their `_quarto.yml`

This is useful for people adding interlinks internally within a package, without wanting to add any external inventories.