### PR TITLE
fix: dynamic child should load parent dynamically

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -346,7 +346,7 @@ def dynamic_alias(
         else:
             parent_path = mod_name.rsplit(".", 1)[0]
 
-        parent = get_object(parent_path, loader=loader)
+        parent = get_object(parent_path, loader=loader, dynamic=True)
         return dc.Alias(attr_name, obj, parent=parent)
 
 

--- a/quartodoc/tests/example_star_imports.py
+++ b/quartodoc/tests/example_star_imports.py
@@ -1,0 +1,1 @@
+from quartodoc.tests.example import *  # noqa

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -210,6 +210,21 @@ def test_blueprint_fetch_members_include_inherited():
     assert "some_method" in member_names
 
 
+def test_blueprint_fetch_members_dynamic():
+    # Since AClass is imported via star import it has to be dynamically
+    # resolved. This test ensures that the members of AClass also get
+    # loaded correctly.
+    name = "quartodoc.tests.example_star_imports:AClass"
+    auto = lo.Auto(name=name, members=["a_method"], dynamic=True)
+    bp = blueprint(auto)
+
+    method_path = "quartodoc.tests.example_star_imports.AClass.a_method"
+
+    assert len(bp.members) == 1
+    assert bp.members[0].obj.path == method_path
+    assert bp.members[0].obj.parent.path == name.replace(":", ".")
+
+
 def test_blueprint_member_options():
     auto = lo.Auto(
         name="quartodoc.tests.example",


### PR DESCRIPTION
It appears that when a class is star imported, then when its members are dynamically loaded, they may have issues fetching the class. I resolved by setting it so that when a method is being dynamically loaded, it also tries to dynamically load its parent.