### PR TITLE
docs: add signature_name to docstring and all content options section

### DIFF
--- a/docs/get-started/basic-content.qmd
+++ b/docs/get-started/basic-content.qmd
@@ -375,3 +375,21 @@ Note these three important pieces of the page entry:
 * `contents:` - lists out the contents of the page.
 
 
+## All content options
+
+```{python}
+#| echo: false
+#| output: asis
+
+# print out the attributes table of ChoicesChildren 
+# this is overkill, but maybe a nice case of dogfooding
+from quartodoc import get_object, MdRenderer, Auto
+from quartodoc.builder.utils import extract_type
+from griffe.docstrings.dataclasses import DocstringSectionAttributes
+
+renderer = MdRenderer()
+choices = get_object("quartodoc.Auto")
+res = extract_type(DocstringSectionAttributes, choices.docstring.parsed)[0]
+
+print(renderer.render(res))
+```

--- a/docs/get-started/basic-content.qmd
+++ b/docs/get-started/basic-content.qmd
@@ -377,12 +377,13 @@ Note these three important pieces of the page entry:
 
 ## All content options
 
+Below is a summary of all the options that can be applied to individual content entries.
+
+
 ```{python}
 #| echo: false
 #| output: asis
 
-# print out the attributes table of ChoicesChildren 
-# this is overkill, but maybe a nice case of dogfooding
 from quartodoc import get_object, MdRenderer, Auto
 from quartodoc.builder.utils import extract_type
 from griffe.docstrings.dataclasses import DocstringSectionAttributes

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -241,9 +241,12 @@ class Auto(AutoOptions):
 
     Attributes
     ----------
-    kind:
     name:
         Name of the object. This should be the path needed to import it.
+    signature_name:
+        Style of name to use in the signature. Can be "relative", "full", or "short".
+        Relative is whatever was used as the name argument, full is the fully qualified
+        path the object, and short is the name of the object (i.e. no periods).
     members:
         A list of members, such as attributes or methods on a class, to document.
     include_private:
@@ -274,7 +277,6 @@ class Auto(AutoOptions):
         If specified, object lookup will be relative to this path.
     member_options:
         Options to apply to members. These can include any of the options above.
-
 
     """
 


### PR DESCRIPTION
This PR documents the signature_name argument, which controls how much of an objects name to show in its signature. E.g.

* relative (default): whatever the user specified as the `name:` argument
* full: the full path to the object
* short: just the object name (i.e. no periods)