### PR TITLE
docs: add ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Overview
 
+[![CI](https://github.com/machow/quartodoc/actions/workflows/ci.yml/badge.svg)](https://github.com/machow/quartodoc/actions/workflows/ci.yml)
+
 **quartodoc** lets you quickly generate Python package API reference
 documentation using Markdown and [Quarto](https://quarto.org). quartodoc
 is designed as an alternative to

--- a/docs/GITHUB.qmd
+++ b/docs/GITHUB.qmd
@@ -1,9 +1,14 @@
 ---
+title: quartodoc
 replace_base_domain: "https://machow.github.io/quartodoc"
 replace_rel_path: "/get-started"
 filters:
   - _filters/replace-readme-links.lua
 format: gfm
 ---
+
+```{=markdown}
+[![CI](https://github.com/machow/quartodoc/actions/workflows/ci.yml/badge.svg)](https://github.com/machow/quartodoc/actions/workflows/ci.yml)
+```
 
 {{< include get-started/overview.qmd >}}

--- a/docs/get-started/overview.qmd
+++ b/docs/get-started/overview.qmd
@@ -37,7 +37,6 @@ if "BUILDING_README" in os.environ:
 
 <br>
 
-## Installation
 """)
 else:
     print("""


### PR DESCRIPTION
This PR takes @hamelsmu 's work in #261 and adds the CI badge to our github readme. Since we now generate the readme based on the quartodoc homepage (overview.qmd), I added it there!

Note that I had to add a title to our `GITHUB.qmd` to work around a strange quarto bug (https://github.com/quarto-dev/quarto-cli/issues/7157), but the title set there doesn't apply (since quarto uses the title from the included document by design).