### PR TITLE
Dev pydantic compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
       matrix:
         # Checks based on python versions ---
         python-version: ['3.9', '3.10']
+        requirements: [""]
+
+        include:
+          - name: "pydantic v1"
+            requirements: "pydantic<2.0.0"
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +32,13 @@ jobs:
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev]"
+
+          # include requirements if specified
+          if [ -n "$REQUIREMENTS" ]; then
+            python -m pip install $REQUIREMENTS '.[dev]'
+          else
+            python -m pip install '.[dev]'
+          fi
       - name: Run tests
         run: |
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           else
             python -m pip install '.[dev]'
           fi
+        env:
+          REQUIREMENTS: ${{ matrix.requirements }}
       - name: Run tests
         run: |
           pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "tabulate >= 0.9.0",
     "importlib-metadata >= 5.1.0",
     "importlib-resources >= 5.10.2",
-    "pydantic < 2.0",
+    "pydantic",
     "pyyaml",
     "typing-extensions >= 4.4.0",
     "watchdog >= 3.0.0",

--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -10,7 +10,7 @@ from watchdog.observers import Observer
 from functools import partial
 from watchdog.events import PatternMatchingEventHandler
 from quartodoc import Builder, convert_inventory
-from pydantic import BaseModel
+from ._pydantic_compat import BaseModel
 
 
 def get_package_path(package_name):

--- a/quartodoc/_pydantic_compat.py
+++ b/quartodoc/_pydantic_compat.py
@@ -1,0 +1,10 @@
+try:
+    from pydantic.v1 import (
+        BaseModel,
+        Field,
+        Extra,
+        PrivateAttr,
+        ValidationError,
+    )  # noqa
+except ImportError:
+    from pydantic import BaseModel, Field, Extra, PrivateAttr, ValidationError  # noqa

--- a/quartodoc/ast.py
+++ b/quartodoc/ast.py
@@ -8,8 +8,8 @@ from griffe.docstrings import dataclasses as ds
 from griffe import dataclasses as dc
 from plum import dispatch
 from typing import Union
-from pydantic import BaseModel  # for previewing
 
+from ._pydantic_compat import BaseModel  # for previewing
 
 # Transform and patched-in classes ============================================
 # TODO: annotate transform return types. make sure subtypes inherit from correct

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -15,13 +15,14 @@ from griffe import dataclasses as dc
 from plum import dispatch  # noqa
 from pathlib import Path
 from types import ModuleType
-from pydantic import ValidationError
 
 from .inventory import create_inventory, convert_inventory
 from . import layout
 from .parsers import get_parser_defaults
 from .renderers import Renderer
-from .validation import fmt
+from .validation import fmt_all
+from ._pydantic_compat import ValidationError
+
 
 from typing import Any
 
@@ -485,12 +486,7 @@ class Builder:
         try:
             return layout.Layout(sections=sections, package=package, options=options)
         except ValidationError as e:
-            msg = "Configuration error for YAML:\n - "
-            errors = [fmt(err) for err in e.errors() if fmt(err)]
-            first_error = errors[
-                0
-            ]  # we only want to show one error at a time b/c it is confusing otherwise
-            msg += first_error
+            msg = fmt_all(e)
             raise ValueError(msg) from None
 
     # building ----------------------------------------------------------------

--- a/quartodoc/builder/_node.py
+++ b/quartodoc/builder/_node.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from quartodoc._pydantic_compat import BaseModel
 from typing import Any, Optional
 
 

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -36,7 +36,7 @@ from typing import overload, TYPE_CHECKING
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel
+    from quartodoc._pydantic_compat import BaseModel
 
 
 def _auto_package(mod: dc.Module) -> list[Section]:

--- a/quartodoc/builder/utils.py
+++ b/quartodoc/builder/utils.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from plum import dispatch
-from pydantic import BaseModel
 from typing import Union
 
+from quartodoc._pydantic_compat import BaseModel
 from ._node import Node
 
 

--- a/quartodoc/interlinks.py
+++ b/quartodoc/interlinks.py
@@ -18,10 +18,11 @@ import json
 import warnings
 import yaml
 
-from pydantic import BaseModel, Field
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Annotated, Union, Optional
+
+from ._pydantic_compat import BaseModel, Field
 
 
 ENV_PROJECT_ROOT: str = "QUARTO_PROJECT_ROOT"

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -414,7 +414,7 @@ ContentElement = Annotated[
 ]
 """Entry in the contents list."""
 
-ContentList = list[Union[ContentElement, Doc, _AutoDefault]]
+ContentList = list[Union[_AutoDefault, ContentElement, Doc]]
 
 # Item ----
 

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -4,10 +4,10 @@ import griffe.dataclasses as dc
 import logging
 
 from enum import Enum
-from pydantic import BaseModel, Field, Extra, PrivateAttr
-
 from typing_extensions import Annotated
 from typing import Literal, Union, Optional
+
+from ._pydantic_compat import BaseModel, Field, Extra, PrivateAttr
 
 
 _log = logging.getLogger(__name__)

--- a/quartodoc/tests/__snapshots__/test_validation.ambr
+++ b/quartodoc/tests/__snapshots__/test_validation.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_misplaced_kindpage
+  '''
+  Code:
+  
+      quartodoc:
+        package: zzz
+        sections:
+          - kind: page
+  
+  
+  Error:
+      Configuration error for YAML:
+       - Missing field `path` for element 0 in the list for `sections`, which you need when setting `kind: page`.
+  
+  '''
+# ---
+# name: test_missing_name_contents_2
+  '''
+  Code:
+  
+      quartodoc:
+        package: zzz
+        sections:
+          - title: Section 1
+          - title: Section 2
+            contents:
+              - children: linked
+              - name: MdRenderer
+  
+  Error:
+      Configuration error for YAML:
+       - Missing field `name` for element 0 in the list for `contents` located in element 1 in the list for `sections`
+  
+  '''
+# ---

--- a/quartodoc/tests/__snapshots__/test_validation.ambr
+++ b/quartodoc/tests/__snapshots__/test_validation.ambr
@@ -15,7 +15,7 @@
   
   '''
 # ---
-# name: test_missing_name_contents_2
+# name: test_missing_name_contents
   '''
   Code:
   
@@ -25,7 +25,10 @@
           - title: Section 1
           - title: Section 2
             contents:
+  
+              # name missing here ----
               - children: linked
+  
               - name: MdRenderer
   
   Error:

--- a/quartodoc/tests/test_ast.py
+++ b/quartodoc/tests/test_ast.py
@@ -95,7 +95,9 @@ def test_preview_warn_alias_no_load():
         qast.preview(obj)
 
     msg = record[0].message.args[0]
-    assert "Could not resolve Alias target `pydantic.BaseModel`" in msg
+    assert (
+        "Could not resolve Alias target `quartodoc._pydantic_compat.BaseModel`" in msg
+    )
 
 
 @pytest.mark.parametrize(

--- a/quartodoc/tests/test_layout.py
+++ b/quartodoc/tests/test_layout.py
@@ -1,7 +1,8 @@
 import pytest
 
-from pydantic import ValidationError
 from quartodoc.layout import Layout, Page, Text, Section  # noqa
+
+from quartodoc._pydantic_compat import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/quartodoc/tests/test_validation.py
+++ b/quartodoc/tests/test_validation.py
@@ -21,61 +21,7 @@ Error:\n{fmt_value}
 """
 
 
-@pytest.mark.skip("title is now optional")
-def test_missing_title():
-    "Test that missing title raises an error"
-
-    cfg = """
-    quartodoc:
-      package: zzz
-      sections:
-        - desc: "abc"
-          contents:
-            - get_object
-    """
-
-    check_ValueError(cfg)
-    # assert "- Missing field `title` for element 0 in the list for `sections`" in msg
-
-
-@pytest.mark.skip("desc is now optional")
-def test_missing_desc():
-    "Test that a missing description raises an error"
-
-    cfg = """
-    quartodoc:
-      package: zzz
-      sections:
-        - title: "A section"
-          contents:
-            - get_object
-    """
-
-    check_ValueError(cfg)
-    # assert "- Missing field `desc` for element 2 in the list for `sections`" in msg
-
-
-@pytest.mark.skip("contents is now optional")
-def test_missing_name_contents_1():
-    "Test that a missing name in contents raises an error"
-
-    cfg = """
-    quartodoc:
-      package: zzz
-      sections:
-        - title: "A section"
-          contents:
-            - get_object
-    """
-
-    check_ValueError(cfg)
-    # assert (
-    #     "- Missing field `name` for element 0 in the list for `contents` located in element 2 in the list for `sections`"
-    #     in msg
-    # )
-
-
-def test_missing_name_contents_2(snapshot):
+def test_missing_name_contents(snapshot):
     "Test that a missing name in contents raises an error in a different section."
 
     cfg = """
@@ -85,7 +31,10 @@ def test_missing_name_contents_2(snapshot):
         - title: Section 1
         - title: Section 2
           contents:
+
+            # name missing here ----
             - children: linked
+
             - name: MdRenderer
     """
 

--- a/quartodoc/tests/test_validation.py
+++ b/quartodoc/tests/test_validation.py
@@ -40,10 +40,6 @@ def test_missing_name_contents(snapshot):
 
     msg = check_ValueError(cfg)
     assert msg == snapshot
-    # assert (
-    #     "- Missing field `name` for element 0 in the list for `contents` located in element 1 in the list for `sections`"
-    #     in msg
-    # )
 
 
 def test_misplaced_kindpage(snapshot):
@@ -57,18 +53,5 @@ def test_misplaced_kindpage(snapshot):
 
     """
 
-    # the challenge with the pydantic feedback here is that, since Section now does
-    # not need to have title, desc, or contents. It believes the `kind: page` is a
-    # screwed up section :/.
-    # It seems like we need to intercept any error where kind is specified, and
-    # customize our message (e.g. we know kind: "page" indicates someone is trying
-    # to specify a Page)
     msg = check_ValueError(cfg)
     assert msg == snapshot
-
-    # sections[0]["kind"] = "page"
-    # msg = check_ValueError(sections)
-    # assert (
-    #     " - Missing field `path` for element 0 in the list for `sections`, which you need when setting `kind: page`."
-    #     in msg
-    # )

--- a/quartodoc/tests/test_validation.py
+++ b/quartodoc/tests/test_validation.py
@@ -1,79 +1,125 @@
-import copy
 import pytest
+import yaml
+
+from textwrap import indent, dedent
 
 from quartodoc.autosummary import Builder
 
-EXAMPLE_SECTIONS = [
-    {
-        "title": "Preperation Functions",
-        "desc": "Functions that fetch objects.\nThey prepare a representation of the site.\n",
-        "contents": ["Auto", "blueprint", "collect", "get_object", "preview"],
-    },
-    {
-        "title": "Docstring Renderers",
-        "desc": "Renderers convert parsed docstrings into a target format, like markdown.\n",
-        "contents": [
-            {"name": "MdRenderer", "children": "linked"},
-            {"name": "MdRenderer.render", "dynamic": True},
-            {"name": "MdRenderer.render_annotation", "dynamic": True},
-            {"name": "MdRenderer.render_header", "dynamic": True},
-        ],
-    },
-    {
-        "title": "API Builders",
-        "desc": "Builders build documentation. They tie all the pieces\nof quartodoc together.\n",
-        "contents": [
-            {"kind": "auto", "name": "Builder", "members": []},
-            "Builder.from_quarto_config",
-            "Builder.build",
-            "Builder.write_index",
-        ],
-    },
-]
 
-
-@pytest.fixture
-def sections():
-    return copy.deepcopy(EXAMPLE_SECTIONS)
-
-
-def check_ValueError(sections):
+def check_ValueError(cfg: str):
     "Check that a ValueError is raised when creating a `Builder` instance. Return the error message as a string."
+
+    d = yaml.safe_load(cfg)
     with pytest.raises(ValueError) as e:
-        Builder(sections=sections, package="quartodoc")
-    return str(e.value)
+        Builder.from_quarto_config(d)
+
+    fmt_cfg = indent(dedent(cfg), " " * 4)
+    fmt_value = indent(str(e.value), " " * 4)
+    return f"""\
+Code:\n{fmt_cfg}
+Error:\n{fmt_value}
+"""
 
 
-def test_valid_yaml(sections):
-    "Test that valid YAML passes validation"
-    Builder(sections=sections, package="quartodoc")
+@pytest.mark.skip("title is now optional")
+def test_missing_title():
+    "Test that missing title raises an error"
+
+    cfg = """
+    quartodoc:
+      package: zzz
+      sections:
+        - desc: "abc"
+          contents:
+            - get_object
+    """
+
+    check_ValueError(cfg)
+    # assert "- Missing field `title` for element 0 in the list for `sections`" in msg
 
 
-def test_missing_name_contents_1(sections):
+@pytest.mark.skip("desc is now optional")
+def test_missing_desc():
+    "Test that a missing description raises an error"
+
+    cfg = """
+    quartodoc:
+      package: zzz
+      sections:
+        - title: "A section"
+          contents:
+            - get_object
+    """
+
+    check_ValueError(cfg)
+    # assert "- Missing field `desc` for element 2 in the list for `sections`" in msg
+
+
+@pytest.mark.skip("contents is now optional")
+def test_missing_name_contents_1():
     "Test that a missing name in contents raises an error"
-    del sections[2]["contents"][0]["name"]
-    msg = check_ValueError(sections)
-    assert (
-        "- Missing field `name` for element 0 in the list for `contents` located in element 2 in the list for `sections`"
-        in msg
-    )
+
+    cfg = """
+    quartodoc:
+      package: zzz
+      sections:
+        - title: "A section"
+          contents:
+            - get_object
+    """
+
+    check_ValueError(cfg)
+    # assert (
+    #     "- Missing field `name` for element 0 in the list for `contents` located in element 2 in the list for `sections`"
+    #     in msg
+    # )
 
 
-def test_missing_name_contents_2(sections):
+def test_missing_name_contents_2(snapshot):
     "Test that a missing name in contents raises an error in a different section."
-    del sections[1]["contents"][0]["name"]
-    msg = check_ValueError(sections)
-    assert (
-        "- Missing field `name` for element 0 in the list for `contents` located in element 1 in the list for `sections`"
-        in msg
-    )
+
+    cfg = """
+    quartodoc:
+      package: zzz
+      sections:
+        - title: Section 1
+        - title: Section 2
+          contents:
+            - children: linked
+            - name: MdRenderer
+    """
+
+    msg = check_ValueError(cfg)
+    assert msg == snapshot
+    # assert (
+    #     "- Missing field `name` for element 0 in the list for `contents` located in element 1 in the list for `sections`"
+    #     in msg
+    # )
 
 
-def test_misplaced_kindpage(sections):
+def test_misplaced_kindpage(snapshot):
     "Test that a misplaced kind: page raises an error"
-    sections[0]["kind"] = "page"
-    msg = check_ValueError(sections)
-    assert (
-        " - Missing field `path` for element 0 in the list for `sections`, which you need when setting `kind: page`."
-        in msg
-    )
+
+    cfg = """
+    quartodoc:
+      package: zzz
+      sections:
+        - kind: page
+
+    """
+
+    # the challenge with the pydantic feedback here is that, since Section now does
+    # not need to have title, desc, or contents. It believes the `kind: page` is a
+    # screwed up section :/.
+    # It seems like we need to intercept any error where kind is specified, and
+    # customize our message (e.g. we know kind: "page" indicates someone is trying
+    # to specify a Page)
+    msg = check_ValueError(cfg)
+    assert msg == snapshot
+
+    # sections[0]["kind"] = "page"
+    # msg = check_ValueError(sections)
+    # assert (
+    #     " - Missing field `path` for element 0 in the list for `sections`, which you need when setting `kind: page`."
+    #     in msg
+    # )

--- a/quartodoc/validation.py
+++ b/quartodoc/validation.py
@@ -1,5 +1,67 @@
+"""User-friendly messages for configuration validation errors.
+
+This module has largely two goals:
+
+* Show the most useful error (pydantic starts with the highest, broadest one).
+* Make the error message very user-friendly.
+
+The key dynamic for understanding formatting is that pydantic is very forgiving.
+It will coerce values to the target type, and by default allows extra fields.
+Critically, if you have a union of types, it will try each type in order until it
+finds a match. In this case, it reports errors for everything it tried.
+
+For example, consider this config:
+
+quartodoc:
+    package: zzz
+    sections:
+    - title: Section 1
+      contents:
+        # name missing here ----
+        - children: linked
+
+In this case, the first element of contents is missing a name field.  Since the
+first type in the union for content elements is _AutoDefault, that is what it
+tries (and logs an error about name). However, it then goes down the list of other
+types in the union and logs errors for those (e.g. Doc). This produce a lot of
+confusing messages, because nowhere does it make clear what type its trying to create.
+
+We don't want error messages for everything it tried, just the first type in the union.
+(For a discriminated union, it uses the `kind:` field to know what the first type to try is).
+"""
+
+
+def fmt_all(e):
+    # if not pydantic.__version__.startswith("1."):
+    #    # error reports are much better in pydantic v2
+    #    # so we just use those.
+    #    return str(e)
+
+    errors = [fmt(err) for err in e.errors() if fmt(err)]
+
+    # the last error is the most specific, while earlier ones can be
+    # for alternative union types that didn't work out.
+    main_error = errors[0]
+
+    msg = f"Configuration error for YAML:\n - {main_error}"
+    return msg
+
+
 def fmt(err: dict):
     "format error messages from pydantic."
+
+    # each entry of loc is a new level in the config tree
+    # 0 is root
+    # 1 is sections
+    # 2 is a section entry
+    # 3 is contents
+    # 4 is a content item
+    # 5 might be Auto.members, etc..
+    # 6 might be an Auto.members item
+
+    # type: value_error.discriminated_union.missing_discriminator
+    # type: value_error.missing
+    # type: value_error.extra
     msg = ""
     if err["msg"].startswith("Discriminator"):
         return msg


### PR DESCRIPTION
This PR addresses #209, by using `pydantic.v1` to kick the can down the road. This approach seems to be much easier to do for now, as writing v1 and v2 compatible code requires a lot of tricky moves (e.g. handling the `__root__` change, etc..).