### PR TITLE
docs: configuring docstring styles

### DIFF
--- a/docs/get-started/docstring-style.qmd
+++ b/docs/get-started/docstring-style.qmd
@@ -7,7 +7,17 @@ jupyter:
     name: python3
 ---
 
-quartodoc expects numpydoc style for docstrings.
+quartodoc prefers numpy style for docstrings, but can support other styles by configuring parser in your [quartodoc site options](./basic-docs.qmd) of `_quarto.yml`:
+
+```yaml
+quartodoc:
+  parser: google
+```
+
+Currently, google, sphinx, and numpy are supported. Parsing is handled by the tool [griffe](https://github.com/mkdocstrings/griffe).
+
+### Resources
+
 See the [numpydoc sections guide][numpydoc] for more information and examples.
 
 [numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html#sections

--- a/docs/get-started/docstring-style.qmd
+++ b/docs/get-started/docstring-style.qmd
@@ -1,5 +1,5 @@
 ---
-title: numpydoc style
+title: Docstring formats
 jupyter:
   kernelspec:
     display_name: Python 3 (ipykernel)


### PR DESCRIPTION
Documents how to configure sphinx and google style docstrings. (Previously, the section said only numpy was supported).