### PR TITLE
fix: really add cwd to sys path this time

### DIFF
--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -192,6 +192,10 @@ def build(config, filter, dry_run, watch, verbose):
     if dry_run:
         pass
     else:
+        # add current directory to path, and then temporarily switch directories.
+        # this supports the case where a user is depending on the current directory
+        # for imports
+        sys.path.append(os.getcwd())
         with chdir(Path(config).parent):
             if watch:
                 pkg_path = get_package_path(builder.package)


### PR DESCRIPTION
It looks like in https://github.com/machow/quartodoc/pull/297, I reverted to the original behavior of changing directories to where `_quarto.yml` lives, but did not append the cwd to `sys.path` before switching.
