### PR TITLE
chore: bump griffe to >=0.33, <=0.38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "click",
-    "griffe <= 0.32.3",
+    "griffe >= 0.33, <= 0.38",
     "sphobjinv >= 2.3.1",
     "tabulate >= 0.9.0",
     "importlib-metadata >= 5.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "click",
-    "griffe >= 0.33, <= 0.38",
+    "griffe >= 0.33",
     "sphobjinv >= 2.3.1",
     "tabulate >= 0.9.0",
     "importlib-metadata >= 5.1.0",

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -6,19 +6,13 @@ from contextlib import contextmanager
 from functools import wraps
 from griffe.docstrings import dataclasses as ds
 from griffe import dataclasses as dc
+from griffe import expressions as expr
 from tabulate import tabulate
 from plum import dispatch
 from typing import Tuple, Union, Optional
 from quartodoc import layout
 
 from .base import Renderer, escape, sanitize, convert_rst_link_to_md
-
-
-try:
-    # Name and Expression were moved to expressions in v0.28
-    from griffe import expressions as expr
-except ImportError:
-    from griffe import dataclasses as expr
 
 
 def _has_attr_section(el: dc.Docstring | None):
@@ -130,16 +124,16 @@ class MdRenderer(Renderer):
         return ""
 
     @dispatch
-    def render_annotation(self, el: expr.Name) -> str:
+    def render_annotation(self, el: expr.ExprName) -> str:
         # TODO: maybe there is a way to get tabulate to handle this?
         # unescaped pipes screw up table formatting
         if self.render_interlinks:
-            return f"[{sanitize(el.source)}](`{el.full}`)"
+            return f"[{sanitize(el.name)}](`{el.canonical_path}`)"
 
-        return sanitize(el.source)
+        return sanitize(el.canonical_path)
 
     @dispatch
-    def render_annotation(self, el: expr.Expression) -> str:
+    def render_annotation(self, el: expr.Expr) -> str:
         return "".join(map(self.render_annotation, el))
 
     # signature method --------------------------------------------------------

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -94,7 +94,7 @@ def test_render_doc_attribute(renderer):
     attr = ds.DocstringAttribute(
         name="abc",
         description="xyz",
-        annotation=exp.Expression(exp.Name("Optional", full="Optional"), "[", "]"),
+        annotation=exp.ExprSubscript(exp.ExprName("Optional"), ""),
         value=1,
     )
 


### PR DESCRIPTION
BREAKING CHANGE: This commit may break renderers implemented by
downstream users if they use the `griffe.expressions` module.

Over the past 8 months (and about 10 releases), griffe has had
2 releases that have broken quartodoc. So the griffe requirement
is set to include only the current known working versions.
