### PR TITLE
fix: get_object dynamic supports methods set by assignments

### DIFF
--- a/quartodoc/tests/example_alias_target.py
+++ b/quartodoc/tests/example_alias_target.py
@@ -6,3 +6,7 @@ from quartodoc.tests.example_alias_target__nested import (  # noqa: F401
 
 def alias_target():
     """An alias target"""
+
+
+class AClass:
+    some_method = nested_alias_target

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -114,3 +114,18 @@ def test_get_object_dynamic_module_attr_class_instance():
 
     assert obj.path == "quartodoc.tests.example_dynamic.some_instance"
     assert obj.docstring.value == "Dynamic instance doc"
+
+
+def test_get_object_dynamic_class_method_assigned():
+    # method is assigned to class using
+    # some_method = some_function
+    obj = get_object(
+        "quartodoc.tests.example_alias_target:AClass.some_method", dynamic=True
+    )
+
+    assert isinstance(obj, dc.Alias)
+    assert isinstance(obj.target, dc.Function)
+    assert (
+        obj.target.path
+        == "quartodoc.tests.example_alias_target__nested.nested_alias_target"
+    )


### PR DESCRIPTION
This PR allows for dynamically documenting methods defined like...

```python
from some_module import some_func

class SomeClass:
    some_method = some_func
```

I refactored the approach we use to look for the canonical path to an object. Previously, it wasn't always finding where the dynamic objects lived, and so resulted in returning something closer to the static result. This means that in the above case it believed some_method was an attribute.

I moved the logic for looking for where an object lives into `_canonical_path`, so hopefully it is easier to add and test new cases.