### PR TITLE
Fix dynamic load members

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -381,11 +381,8 @@ def _canonical_path(crnt_part: object, qualname: str):
             return crnt_part.__name__ + suffix
         else:
             return None
-    elif isinstance(crnt_part, ModuleType):
+    else:
         # final object is module
-        if not qualname:
-            return crnt_part.__name__
-
         return crnt_part.__name__ + suffix
 
 

--- a/quartodoc/tests/example_dynamic.py
+++ b/quartodoc/tests/example_dynamic.py
@@ -3,6 +3,13 @@ from functools import partial
 NOTE = "Notes\n----\nI am a note"
 
 
+a: int
+"""The a module attribute"""
+
+b: str = "2"
+"""The b module attribute"""
+
+
 def f(a, b, c):
     """Return something
 

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -129,3 +129,9 @@ def test_get_object_dynamic_class_method_assigned():
         obj.target.path
         == "quartodoc.tests.example_alias_target__nested.nested_alias_target"
     )
+
+
+def test_get_object_dynamic_class_attr_valueless():
+    obj = get_object("quartodoc.tests.example_dynamic:InstanceAttrs.z", dynamic=True)
+
+    assert obj.docstring.value == "The z attribute"


### PR DESCRIPTION
This PR addresses https://github.com/machow/quartodoc/issues/307, by ensuring we can (again) dynamically load value-less attributes off of classes and modules.

It contains additional tests for

* `_canonical_path()` - the function that attempts to go from <some_object> -> its canonical path (i.e. the submodule in which it is defined)
* `get_object(..., dynamic=True)` for more cases

See also https://github.com/machow/quartodoc/issues/308 for a proposal to improve how we get docstrings for instances.