### PR TITLE
Define pandoc InlineContent type to be recursive

### DIFF
--- a/quartodoc/pandoc/blocks.py
+++ b/quartodoc/pandoc/blocks.py
@@ -20,6 +20,7 @@ from quartodoc.pandoc.components import Attr
 from quartodoc.pandoc.inlines import (
     Inline,
     InlineContent,
+    InlineContentItem,
     inlinecontent_to_str,
     str_as_list_item,
 )
@@ -79,8 +80,8 @@ class Block:
 
 # TypeAlias declared here to avoid forward-references which
 # break beartype
-ContentItem: TypeAlias = Union[str, Inline, Block]
-BlockContent: TypeAlias = Union[ContentItem, Sequence[ContentItem]]
+BlockContentItem: TypeAlias = Union[InlineContentItem, Block]
+BlockContent: TypeAlias = Union[BlockContentItem, Sequence[BlockContentItem]]
 DefinitionItem: TypeAlias = tuple[InlineContent, BlockContent]
 
 

--- a/quartodoc/pandoc/blocks.py
+++ b/quartodoc/pandoc/blocks.py
@@ -157,8 +157,10 @@ class DefinitionList(Block):
             # Single Definition
             if isinstance(definitions, (str, Inline, Block)):
                 definitions = [definitions]
+            elif definitions is None:
+                definitions = [""]
 
-            # Multiple defnitions
+            # Multiple definitions
             for definition in definitions:
                 s = blockcontent_to_str(definition)
                 # strip away the indentation on the first line as it
@@ -398,6 +400,7 @@ def blockcontent_to_str_items(
         it = (
             str_as_list_item(c) if isinstance(c, str) else c.as_list_item
             for c in content
+            if c
         )
         items = (fmt(s, next(pfx_it)) for s in it)
         return "".join(items).strip()

--- a/quartodoc/pandoc/inlines.py
+++ b/quartodoc/pandoc/inlines.py
@@ -65,7 +65,7 @@ class Inline:
 
 # TypeAlias declared here to avoid forward-references which
 # break beartype
-InlineContentItem = Union[str, Inline]
+InlineContentItem = Union[str, Inline, None]
 InlineContent: TypeAlias = Union[InlineContentItem, Sequence[InlineContentItem]]
 
 

--- a/quartodoc/pandoc/inlines.py
+++ b/quartodoc/pandoc/inlines.py
@@ -65,7 +65,8 @@ class Inline:
 
 # TypeAlias declared here to avoid forward-references which
 # break beartype
-InlineContent: TypeAlias = Union[str, Inline, Union[Sequence[str], Inline]]
+InlineContentItem = Union[str, Inline]
+InlineContent: TypeAlias = Union[InlineContentItem, Sequence[InlineContentItem]]
 
 
 @dataclass

--- a/quartodoc/tests/pandoc/test_blocks.py
+++ b/quartodoc/tests/pandoc/test_blocks.py
@@ -86,6 +86,25 @@ d
 """.strip()
     )
 
+    b = Blocks([Div("a"), None, Div("c")])
+    assert (
+        str(b)
+        == """
+::: {}
+a
+:::
+
+::: {}
+c
+:::
+""".strip()
+    )
+
+    b1 = Blocks([None, None])
+    b2 = Blocks(["", "", ""])
+    assert str(b1) == ""
+    assert str(b2) == ""
+
 
 def test_bulletlist():
     b = BulletList(["a", "b", "c"])
@@ -281,6 +300,13 @@ Term 2
     ```
 """.strip()
     )
+
+    # Empty definitions are valid, but require trailling spaces after
+    # the colon
+    d1 = DefinitionList([("Term 1", ""), ("Term 2", "Definition 2")])
+    d2 = DefinitionList([("Term 1", None), ("Term 2", "Definition 2")])
+    assert ":   \n" in str(d1)
+    assert str(d1) == str(d2)
 
 
 def test_div():

--- a/quartodoc/tests/pandoc/test_inlines.py
+++ b/quartodoc/tests/pandoc/test_inlines.py
@@ -87,6 +87,9 @@ def test_span():
     s = Span("a", Attr("span-id", classes=["c1", "c2"], attributes={"data-value": "1"}))
     assert str(s) == '[a]{#span-id .c1 .c2 data-value="1"}'
 
+    s = Span([Span("a"), Span("b"), "c"])
+    assert str(s) == "[[a]{} [b]{} c]{}"
+
 
 def test_str():
     s = Str("a")

--- a/quartodoc/tests/pandoc/test_inlines.py
+++ b/quartodoc/tests/pandoc/test_inlines.py
@@ -65,6 +65,12 @@ def test_inlines():
     i = Inlines(["a", Span("b"), Emph("c")])
     assert str(i) == "a [b]{} *c*"
 
+    i = Inlines(["a", None, Span("b"), Emph("c"), None])
+    assert str(i) == "a [b]{} *c*"
+
+    i = Inlines([None, None, None])
+    assert str(i) == ""
+
     i = Inlines(["a", Span("b"), Emph("c"), ["d", Strong("e")]])
     assert str(i) == "a [b]{} *c* d **e**"
 


### PR DESCRIPTION
InlineContent is already processed recursively, this
change makes the type definition recursive too.

And it also defines a clearer relationship between InlineContent
and BlockContent.
