### PR TITLE
Add docs for how to document only Python files

### DIFF
--- a/docs/get-started/basic-content.qmd
+++ b/docs/get-started/basic-content.qmd
@@ -374,6 +374,45 @@ Note these three important pieces of the page entry:
   `some_funcs.qmd` in the API reference folder.
 * `contents:` - lists out the contents of the page.
 
+## Documenting source files that are not a package
+
+In some cases you might want to create a page for a bunch of Python modules that are not a package.
+
+Say you have a repository that look like this:
+
+```
+project
+├── config
+├── data
+├── docs
+├── notebooks
+├── src
+```
+
+Where `src` is the place where you have your `.py` files and `docs` is where your `_quarto.yml` is.
+
+To make a quartodoc page of this project you have to set the package to `null` and tell Quarto where 
+quartodoc should look. Then you can reference each file as usual with `file.function`.
+
+Example:
+
+```yaml
+quartodoc:
+  package: null
+  source_dir: ../src
+
+  # write sidebar data to this file
+  sidebar: _sidebar.yml
+
+  sections:
+    - title: Some functions
+      desc: Some description
+      contents:
+        # the functions being documented in the package.
+        # you can refer to anything: class methods, modules, etc..
+        - analysis.plot_my_vars
+        - training.train_and_evaluate
+```
 
 ## All content options
 


### PR DESCRIPTION
I found the work around for how to use the `source_dir` option correctly in this old issue: https://github.com/machow/quartodoc/issues/130.

I didn't understand how to use it through the docs so this PR adds an example to the docs.

Not sure if it is in the right place, so feel free to move it. I found `quartodoc` really helpful and easy to use (once I managed to find the above issue) to document a Python project that didn't end up as a package.