### PR TITLE
feat!: initial description-list support; render_header cleanup

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -88,6 +88,9 @@ quartodoc:
   dir: api
   package: quartodoc
   render_interlinks: true
+  renderer:
+    style: markdown
+    table_style: description-list
   sidebar: "api/_sidebar.yml"
   sections:
     - title: Preparation Functions

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -79,7 +79,9 @@ website:
 format:
   html:
     theme: cosmo
-    css: styles.css
+    css:
+      - styles.css
+      - styles-quartodoc.css
     toc: true
 
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -80,8 +80,8 @@ format:
   html:
     theme: cosmo
     css:
+      - api/_styles-quartodoc.css
       - styles.css
-      - styles-quartodoc.css
     toc: true
 
 
@@ -94,6 +94,7 @@ quartodoc:
     style: markdown
     table_style: description-list
   sidebar: "api/_sidebar.yml"
+  css: "api/_styles-quartodoc.css"
   sections:
     - title: Preparation Functions
       desc: |

--- a/docs/get-started/overview.qmd
+++ b/docs/get-started/overview.qmd
@@ -77,15 +77,20 @@ project:
 
 # tell quarto to read the generated sidebar
 metadata-files:
-  - _sidebar.yml
+  - api/_sidebar.yml
 
+# tell quarto to read the generated styles
+format:
+  css:
+    - api/_styles-quartodoc.css
 
 quartodoc:
   # the name used to import the package you want to create reference docs for
   package: quartodoc
 
-  # write sidebar data to this file
-  sidebar: _sidebar.yml
+  # write sidebar and style data
+  sidebar: api/_sidebar.yml
+  css: api/_styles-quartodoc.css
 
   sections:
     - title: Some functions

--- a/docs/styles-quartodoc.css
+++ b/docs/styles-quartodoc.css
@@ -1,0 +1,12 @@
+.doc-section dt code {
+    background: none;
+}
+
+.doc-section dt {
+    background-color: lightyellow;
+    display: block;
+}
+
+.doc-section dl dd {
+    margin-left: 3rem;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
+    "black",
     "click",
     "griffe >= 0.33",
     "sphobjinv >= 2.3.1",

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -427,6 +427,8 @@ class Builder:
         The output path of the index file, used to list all API functions.
     sidebar:
         The output path for a sidebar yaml config (by default no config generated).
+    css:
+        The output path for the default css styles.
     rewrite_all_pages:
         Whether to rewrite all rendered doc pages, or only those with changes.
     source_dir:
@@ -486,6 +488,7 @@ class Builder:
         renderer: "dict | Renderer | str" = "markdown",
         out_index: str = None,
         sidebar: "str | None" = None,
+        css: "str | None" = None,
         rewrite_all_pages=False,
         source_dir: "str | None" = None,
         dynamic: bool | None = None,
@@ -502,6 +505,7 @@ class Builder:
         self.dir = dir
         self.title = title
         self.sidebar = sidebar
+        self.css = css
         self.parser = parser
 
         self.renderer = Renderer.from_config(renderer)
@@ -586,6 +590,12 @@ class Builder:
         if self.sidebar:
             _log.info(f"Writing sidebar yaml to {self.sidebar}")
             self.write_sidebar(blueprint)
+
+        # css ----
+
+        if self.css:
+            _log.info(f"Writing css styles to {self.css}")
+            self.write_css()
 
     def write_index(self, blueprint: layout.Layout):
         """Write API index page."""
@@ -684,6 +694,22 @@ class Builder:
 
         d_sidebar = self._generate_sidebar(blueprint)
         yaml.dump(d_sidebar, open(self.sidebar, "w"))
+
+    def write_css(self):
+        """Write default css styles to a file."""
+        from importlib_resources import files
+        from importlib_metadata import version
+
+        v = version("quartodoc")
+
+        note = (
+            f"/*\nThis file generated automatically by quartodoc version {v}.\n"
+            "Modifications may be overwritten by quartodoc build. If you want to\n"
+            "customize styles, create a new .css file to avoid losing changes.\n"
+            "*/\n\n\n"
+        )
+        with open(files("quartodoc.static") / "styles.css") as f:
+            Path(self.css).write_text(note + f.read())
 
     def _page_to_links(self, el: layout.Page) -> list[str]:
         # if el.flatten:

--- a/quartodoc/renderers/base.py
+++ b/quartodoc/renderers/base.py
@@ -17,6 +17,9 @@ def sanitize(val: str, allow_markdown=False):
     # sanitize common tokens that break tables
     res = val.replace("\n", " ").replace("|", "\\|")
 
+    # sanitize elements that get turned into smart quotes
+    res = res.replace("'", r"\'").replace('"', r"\"")
+
     # sanitize elements that can get interpreted as markdown links
     # or citations
     if not allow_markdown:

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -75,13 +75,15 @@ class ParamRow:
         ).html
         return (param, part_desc)
 
-    def to_tuple(self, style: Literal["paramters", "attributes", "returns"]):
+    def to_tuple(self, style: Literal["parameters", "attributes", "returns"]):
+        name = self.name
         if style == "parameters":
-            return (self.name, self.annotation, self.description, self.default)
+            default = "_required_" if self.default is None else escape(self.default)
+            return (name, self.annotation, self.description, default)
         elif style == "attributes":
-            return (self.name, self.annotation, self.description)
+            return (name, self.annotation, self.description)
         elif style == "returns":
-            return (self.name, self.annotation, self.description)
+            return (name, self.annotation, self.description)
 
         raise NotImplementedError(f"Unsupported table style: {style}")
 
@@ -173,7 +175,7 @@ class MdRenderer(Renderer):
         self,
         rows,
         headers,
-        style: Literal["parameters", "attributes", "returns"] = "parameters",
+        style: Literal["parameters", "attributes", "returns"],
     ):
         if self.table_style == "description-list":
             return str(DefinitionList([row.to_definition_list() for row in rows]))
@@ -563,7 +565,7 @@ class MdRenderer(Renderer):
     def render(self, el: ds.DocstringSectionParameters):
         rows: "list[ParamRow]" = list(map(self.render, el.value))
         header = ["Name", "Type", "Description", "Default"]
-        return self._render_table(rows, header)
+        return self._render_table(rows, header, "parameters")
 
     @dispatch
     def render(self, el: ds.DocstringParameter) -> ParamRow:
@@ -578,7 +580,7 @@ class MdRenderer(Renderer):
         header = ["Name", "Type", "Description"]
         rows = list(map(self.render, el.value))
 
-        return self._render_table(rows, header)
+        return self._render_table(rows, header, "attributes")
 
     @dispatch
     def render(self, el: ds.DocstringAttribute) -> ParamRow:
@@ -646,7 +648,7 @@ class MdRenderer(Renderer):
         rows = list(map(self.render, el.value))
         header = ["Name", "Type", "Description"]
 
-        return self._render_table(rows, header)
+        return self._render_table(rows, header, "returns")
 
     @dispatch
     def render(self, el: ds.DocstringReturn):

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -480,7 +480,7 @@ class MdRenderer(Renderer):
     # signature parts -------------------------------------------------------------
 
     @dispatch
-    def render(self, el: dc.Parameters) -> "list[str]":
+    def render(self, el: dc.Parameters) -> "list":
         # index for switch from positional to kw args (via an unnamed *)
         try:
             kw_only = [par.kind for par in el].index(dc.ParameterKind.keyword_only)

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import black
 import quartodoc.ast as qast
 
 from contextlib import contextmanager
@@ -238,7 +239,13 @@ class MdRenderer(Renderer):
         name = self._fetch_object_dispname(source or el)
         pars = self.render(self._fetch_method_parameters(el))
 
-        return f"`{name}({pars})`"
+        flat_sig = f"{name}({pars})"
+        if len(flat_sig) > 80:
+            sig = black.format_str(flat_sig, mode=black.Mode())
+        else:
+            sig = flat_sig
+
+        return f"```python\n{sig}\n```"
 
     @dispatch
     def signature(

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -35,16 +35,10 @@ def _name_description(row: list[str | None]):
         name, default = None, None
     else:
         raise ValueError(f"Unsupported row length: {len(row)}")
-    
-    part_name = (
-        Span(name, Attr(classes=["parameter-name"]))
-        if name is not None
-        else ''
-    )
+
+    part_name = Span(name, Attr(classes=["parameter-name"])) if name is not None else ""
     part_anno = (
-        Span(anno, Attr(classes=["parameter-annotation"]))
-        if anno is not None
-        else ''
+        Span(anno, Attr(classes=["parameter-annotation"])) if anno is not None else ""
     )
 
     # TODO: _required_ is set when parsing parameters, but only used
@@ -54,7 +48,7 @@ def _name_description(row: list[str | None]):
     part_default = (
         Span(f" = {default}", Attr(classes=["parameter-default-sep"]))
         if default is not None and default != "_required_"
-        else ''
+        else ""
     )
 
     part_desc = desc if desc is not None else ""
@@ -64,8 +58,6 @@ def _name_description(row: list[str | None]):
     # TODO: should code wrap the whole thing like this?
     param = Code(str(Inlines([part_name, anno_sep, part_anno, part_default]))).html
     return (param, part_desc)
-
-
 
 
 class MdRenderer(Renderer):
@@ -107,7 +99,7 @@ class MdRenderer(Renderer):
         display_name: str = "relative",
         hook_pre=None,
         render_interlinks=False,
-        #table_style="description-list",
+        # table_style="description-list",
         table_style="table",
     ):
         self.header_level = header_level
@@ -233,13 +225,13 @@ class MdRenderer(Renderer):
         # e.g. get_object, rather than quartodoc.get_object
         _anchor = f"{{ #{el.obj.path} }}"
         return f"{'#' * self.crnt_header_level} {_str_dispname} {_anchor}"
-    
+
     @dispatch
     def render_header(self, el: ds.DocstringSection) -> str:
         title = el.title or el.kind.value
         _classes = [".doc-section", ".doc-section-" + title.replace(" ", "-")]
         _str_classes = " ".join(_classes)
-        return f"{'#' * self.crnt_header_level} {title.title()} {{ {_str_classes} }}"
+        return f"{'#' * self.crnt_header_level} {title.title()} {{{_str_classes}}}"
 
     # render method -----------------------------------------------------------
 

--- a/quartodoc/static/styles.css
+++ b/quartodoc/static/styles.css
@@ -1,9 +1,12 @@
+/* styles for parameter tables, etc.. ----
+*/
+
 .doc-section dt code {
     background: none;
 }
 
 .doc-section dt {
-    background-color: lightyellow;
+    /* background-color: lightyellow; */
     display: block;
 }
 

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -364,3 +364,117 @@
   | `b`    | str    | The b parameter. | _required_ |
   '''
 # ---
+# name: test_render_numpydoc_section_return[int\n    A description.]
+  '''
+  Code
+      Parameters
+      ---
+      int
+          A description.
+  
+      Returns
+      ---
+      int
+          A description.
+  
+      Attributes
+      ---
+      int
+          A description.
+  
+  Default
+      # Parameters
+  
+      | Name   | Type   | Description    | Default    |
+      |--------|--------|----------------|------------|
+      | `int`  |        | A description. | _required_ |
+  
+      # Returns
+  
+      | Name   | Type   | Description    |
+      |--------|--------|----------------|
+      |        | int    | A description. |
+  
+      # Attributes
+  
+      | Name   | Type   | Description    |
+      |--------|--------|----------------|
+      | int    |        | A description. |
+  
+  List
+      # Parameters
+  
+      [`int`]{.parameter-name}[:]{.parameter-annotation-sep}[]{.parameter-annotation}[ = ]{.parameter-default-sep}
+  
+      :   A description.
+  
+      # Returns
+  
+      []{.parameter-name}[:]{.parameter-annotation-sep}[int]{.parameter-annotation}
+  
+      :   A description.
+  
+      # Attributes
+  
+      [int]{.parameter-name}[:]{.parameter-annotation-sep}[]{.parameter-annotation}
+  
+      :   A description.
+  '''
+# ---
+# name: test_render_numpydoc_section_return[name: int\n    A description.]
+  '''
+  Code
+      Parameters
+      ---
+      name: int
+          A description.
+  
+      Returns
+      ---
+      name: int
+          A description.
+  
+      Attributes
+      ---
+      name: int
+          A description.
+  
+  Default
+      # Parameters
+  
+      | Name   | Type   | Description    | Default    |
+      |--------|--------|----------------|------------|
+      | `name` |        | A description. | _required_ |
+  
+      # Returns
+  
+      | Name   | Type   | Description    |
+      |--------|--------|----------------|
+      | name   | int    | A description. |
+  
+      # Attributes
+  
+      | Name   | Type   | Description    |
+      |--------|--------|----------------|
+      | name   | int    | A description. |
+  
+  List
+      # Parameters
+  
+      [`name`]{.parameter-name}[:]{.parameter-annotation-sep}[]{.parameter-annotation}[ = ]{.parameter-default-sep}
+  
+      :   A description.
+  
+      # Returns
+  
+      [name]{.parameter-name}[:]{.parameter-annotation-sep}[int]{.parameter-annotation}
+  
+      :   A description.
+  
+      # Attributes
+  
+      [name]{.parameter-name}[:]{.parameter-annotation-sep}[int]{.parameter-annotation}
+  
+      :   A description.
+  '''
+# ---

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -3,35 +3,47 @@
   '''
   # quartodoc.tests.example_signature.a_complex_signature { #quartodoc.tests.example_signature.a_complex_signature }
   
-  `tests.example_signature.a_complex_signature(x: [list](`list`)\[[C](`quartodoc.tests.example_signature.C`) \| [int](`int`) \| None\], y: [pathlib](`pathlib`).[Pathlib](`pathlib.Pathlib`))`
+  ```python
+  tests.example_signature.a_complex_signature(
+      x: list[C | int | None]
+      y: pathlib.Pathlib
+  )
+  ```
   
   ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type                                                                                 | Description     | Default    |
   |--------|--------------------------------------------------------------------------------------|-----------------|------------|
-  | `x`    | [list](`list`)\[[C](`quartodoc.tests.example_signature.C`) \| [int](`int`) \| None\] | The x parameter | _required_ |
-  | `y`    | [pathlib](`pathlib`).[Pathlib](`pathlib.Pathlib`)                                    | The y parameter | _required_ |
+  | x      | [list](`list`)\[[C](`quartodoc.tests.example_signature.C`) \| [int](`int`) \| None\] | The x parameter | _required_ |
+  | y      | [pathlib](`pathlib`).[Pathlib](`pathlib.Pathlib`)                                    | The y parameter | _required_ |
   '''
 # ---
 # name: test_render_annotations_complex_no_interlinks
   '''
   # quartodoc.tests.example_signature.a_complex_signature { #quartodoc.tests.example_signature.a_complex_signature }
   
-  `tests.example_signature.a_complex_signature(x: list\[C \| int \| None\], y: pathlib.Pathlib)`
+  ```python
+  tests.example_signature.a_complex_signature(
+      x: list[C | int | None]
+      y: pathlib.Pathlib
+  )
+  ```
   
   ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type                     | Description     | Default    |
   |--------|--------------------------|-----------------|------------|
-  | `x`    | list\[C \| int \| None\] | The x parameter | _required_ |
-  | `y`    | pathlib.Pathlib          | The y parameter | _required_ |
+  | x      | list\[C \| int \| None\] | The x parameter | _required_ |
+  | y      | pathlib.Pathlib          | The y parameter | _required_ |
   '''
 # ---
 # name: test_render_doc_class[embedded]
   '''
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
   
-  `tests.example_class.C(self, x, y)`
+  ```python
+  tests.example_class.C(self, x, y)
+  ```
   
   The short summary.
   
@@ -42,8 +54,8 @@
   
   | Name   | Type   | Description          | Default    |
   |--------|--------|----------------------|------------|
-  | `x`    | str    | Uses signature type. | _required_ |
-  | `y`    | int    | Uses manual type.    | _required_ |
+  | x      | str    | Uses signature type. | _required_ |
+  | y      | int    | Uses manual type.    | _required_ |
   
   ## Attributes
   
@@ -61,7 +73,9 @@
   
   ### D { #quartodoc.tests.example_class.C.D }
   
-  `tests.example_class.C.D()`
+  ```python
+  tests.example_class.C.D()
+  ```
   
   A nested class
   
@@ -74,13 +88,17 @@
   
   ### some_class_method { #quartodoc.tests.example_class.C.some_class_method }
   
-  `tests.example_class.C.some_class_method()`
+  ```python
+  tests.example_class.C.some_class_method()
+  ```
   
   A class method
   
   ### some_method { #quartodoc.tests.example_class.C.some_method }
   
-  `tests.example_class.C.some_method()`
+  ```python
+  tests.example_class.C.some_method()
+  ```
   
   A method
   '''
@@ -89,7 +107,9 @@
   '''
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
   
-  `tests.example_class.C(self, x, y)`
+  ```python
+  tests.example_class.C(self, x, y)
+  ```
   
   The short summary.
   
@@ -100,8 +120,8 @@
   
   | Name   | Type   | Description          | Default    |
   |--------|--------|----------------------|------------|
-  | `x`    | str    | Uses signature type. | _required_ |
-  | `y`    | int    | Uses manual type.    | _required_ |
+  | x      | str    | Uses signature type. | _required_ |
+  | y      | int    | Uses manual type.    | _required_ |
   
   ## Attributes
   
@@ -119,7 +139,9 @@
   
   ## D { #quartodoc.tests.example_class.C.D }
   
-  `tests.example_class.C.D()`
+  ```python
+  tests.example_class.C.D()
+  ```
   
   A nested class
   
@@ -132,13 +154,17 @@
   
   ## some_class_method { #quartodoc.tests.example_class.C.some_class_method }
   
-  `tests.example_class.C.some_class_method()`
+  ```python
+  tests.example_class.C.some_class_method()
+  ```
   
   A class method
   
   ## some_method { #quartodoc.tests.example_class.C.some_method }
   
-  `tests.example_class.C.some_method()`
+  ```python
+  tests.example_class.C.some_method()
+  ```
   
   A method
   '''
@@ -147,7 +173,9 @@
   '''
   # quartodoc.tests.example_class.AttributesTable { #quartodoc.tests.example_class.AttributesTable }
   
-  `tests.example_class.AttributesTable(self)`
+  ```python
+  tests.example_class.AttributesTable(self)
+  ```
   
   The short summary.
   
@@ -182,7 +210,9 @@
   
   ### AClass { #quartodoc.tests.example.AClass }
   
-  `tests.example.AClass()`
+  ```python
+  tests.example.AClass()
+  ```
   
   A class
   
@@ -200,7 +230,9 @@
   
   ##### a_method { #quartodoc.tests.example.AClass.a_method }
   
-  `tests.example.AClass.a_method()`
+  ```python
+  tests.example.AClass.a_method()
+  ```
   
   A method
   
@@ -212,7 +244,9 @@
   
   ### a_func { #quartodoc.tests.example.a_func }
   
-  `tests.example.a_func()`
+  ```python
+  tests.example.a_func()
+  ```
   
   A function
   '''
@@ -239,7 +273,9 @@
   
   ## AClass { #quartodoc.tests.example.AClass }
   
-  `tests.example.AClass()`
+  ```python
+  tests.example.AClass()
+  ```
   
   A class
   
@@ -257,7 +293,9 @@
   
   #### a_method { #quartodoc.tests.example.AClass.a_method }
   
-  `tests.example.AClass.a_method()`
+  ```python
+  tests.example.AClass.a_method()
+  ```
   
   A method
   
@@ -269,7 +307,9 @@
   
   ## a_func { #quartodoc.tests.example.a_func }
   
-  `tests.example.a_func()`
+  ```python
+  tests.example.a_func()
+  ```
   
   A function
   '''
@@ -278,7 +318,9 @@
   '''
   # example.a_func { #quartodoc.tests.example.a_func }
   
-  `a_func()`
+  ```python
+  a_func()
+  ```
   
   A function
   '''
@@ -287,7 +329,9 @@
   '''
   # example.a_nested_alias { #quartodoc.tests.example.a_nested_alias }
   
-  `tests.example.a_nested_alias()`
+  ```python
+  tests.example.a_nested_alias()
+  ```
   
   A nested alias target
   '''
@@ -296,7 +340,9 @@
   '''
   # f_numpy_with_linebreaks { #quartodoc.tests.example_docstring_styles.f_numpy_with_linebreaks }
   
-  `tests.example_docstring_styles.f_numpy_with_linebreaks(a, b)`
+  ```python
+  tests.example_docstring_styles.f_numpy_with_linebreaks(a, b)
+  ```
   
   A numpy style docstring.
   
@@ -304,15 +350,17 @@
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
-  | `a`    |        | The a parameter. | _required_ |
-  | `b`    | str    | The b parameter. | _required_ |
+  | a      |        | The a parameter. | _required_ |
+  | b      | str    | The b parameter. | _required_ |
   '''
 # ---
 # name: test_render_docstring_styles[google]
   '''
   # f_google { #quartodoc.tests.example_docstring_styles.f_google }
   
-  `tests.example_docstring_styles.f_google(a, b)`
+  ```python
+  tests.example_docstring_styles.f_google(a, b)
+  ```
   
   A google style docstring.
   
@@ -320,8 +368,8 @@
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
-  | `a`    | int    | The a parameter. | _required_ |
-  | `b`    | str    | The b parameter. | _required_ |
+  | a      | int    | The a parameter. | _required_ |
+  | b      | str    | The b parameter. | _required_ |
   
   ## Custom Admonition {.doc-section .doc-section-Custom-Admonition}
   
@@ -332,7 +380,9 @@
   '''
   # f_numpy { #quartodoc.tests.example_docstring_styles.f_numpy }
   
-  `tests.example_docstring_styles.f_numpy(a, b)`
+  ```python
+  tests.example_docstring_styles.f_numpy(a, b)
+  ```
   
   A numpy style docstring.
   
@@ -340,8 +390,8 @@
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
-  | `a`    |        | The a parameter. | _required_ |
-  | `b`    | str    | The b parameter. | _required_ |
+  | a      |        | The a parameter. | _required_ |
+  | b      | str    | The b parameter. | _required_ |
   
   ## Custom Admonition {.doc-section .doc-section-Custom-Admonition}
   
@@ -352,7 +402,9 @@
   '''
   # f_sphinx { #quartodoc.tests.example_docstring_styles.f_sphinx }
   
-  `tests.example_docstring_styles.f_sphinx(a, b)`
+  ```python
+  tests.example_docstring_styles.f_sphinx(a, b)
+  ```
   
   A sphinx style docstring.
   
@@ -360,8 +412,8 @@
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
-  | `a`    | int    | The a parameter. | _required_ |
-  | `b`    | str    | The b parameter. | _required_ |
+  | a      | int    | The a parameter. | _required_ |
+  | b      | str    | The b parameter. | _required_ |
   '''
 # ---
 # name: test_render_numpydoc_section_return[int\n    A description.]
@@ -387,7 +439,7 @@
   
       | Name   | Type   | Description    | Default    |
       |--------|--------|----------------|------------|
-      | `int`  |        | A description. | _required_ |
+      | int    |        | A description. | _required_ |
   
       # Returns {.doc-section .doc-section-returns}
   
@@ -404,19 +456,19 @@
   List
       # Parameters {.doc-section .doc-section-parameters}
   
-      <code>[`int`]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
+      <code>[**int**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
   
       :   A description.
   
       # Returns {.doc-section .doc-section-returns}
   
-      <code>[]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+      <code>[]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
   
       :   A description.
   
       # Attributes {.doc-section .doc-section-attributes}
   
-      <code>[int]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
+      <code>[**int**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
   
       :   A description.
   '''
@@ -444,7 +496,7 @@
   
       | Name   | Type   | Description    | Default    |
       |--------|--------|----------------|------------|
-      | `name` |        | A description. | _required_ |
+      | name   |        | A description. | _required_ |
   
       # Returns {.doc-section .doc-section-returns}
   
@@ -461,19 +513,19 @@
   List
       # Parameters {.doc-section .doc-section-parameters}
   
-      <code>[`name`]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
+      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
   
       :   A description.
   
       # Returns {.doc-section .doc-section-returns}
   
-      <code>[name]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
   
       :   A description.
   
       # Attributes {.doc-section .doc-section-attributes}
   
-      <code>[name]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
   
       :   A description.
   '''

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -5,7 +5,7 @@
   
   `tests.example_signature.a_complex_signature(x: [list](`list`)\[[C](`quartodoc.tests.example_signature.C`) \| [int](`int`) \| None\], y: [pathlib](`pathlib`).[Pathlib](`pathlib.Pathlib`))`
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type                                                                                 | Description     | Default    |
   |--------|--------------------------------------------------------------------------------------|-----------------|------------|
@@ -19,7 +19,7 @@
   
   `tests.example_signature.a_complex_signature(x: list\[C \| int \| None\], y: pathlib.Pathlib)`
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type                     | Description     | Default    |
   |--------|--------------------------|-----------------|------------|
@@ -38,7 +38,7 @@
   The extended summary,
   which may be multiple lines.
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type   | Description          | Default    |
   |--------|--------|----------------------|------------|
@@ -96,7 +96,7 @@
   The extended summary,
   which may be multiple lines.
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type   | Description          | Default    |
   |--------|--------|----------------------|------------|
@@ -151,7 +151,7 @@
   
   The short summary.
   
-  ## Attributes
+  ## Attributes {.doc-section .doc-section-attributes}
   
   | Name   | Type   | Description         |
   |--------|--------|---------------------|
@@ -300,7 +300,7 @@
   
   A numpy style docstring.
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
@@ -316,14 +316,14 @@
   
   A google style docstring.
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
   | `a`    | int    | The a parameter. | _required_ |
   | `b`    | str    | The b parameter. | _required_ |
   
-  ## Custom Admonition
+  ## Custom Admonition {.doc-section .doc-section-Custom-Admonition}
   
   Some text.
   '''
@@ -336,14 +336,14 @@
   
   A numpy style docstring.
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
   | `a`    |        | The a parameter. | _required_ |
   | `b`    | str    | The b parameter. | _required_ |
   
-  ## Custom Admonition
+  ## Custom Admonition {.doc-section .doc-section-Custom-Admonition}
   
   Some text.
   '''
@@ -356,7 +356,7 @@
   
   A sphinx style docstring.
   
-  ## Parameters
+  ## Parameters {.doc-section .doc-section-parameters}
   
   | Name   | Type   | Description      | Default    |
   |--------|--------|------------------|------------|
@@ -383,40 +383,40 @@
           A description.
   
   Default
-      # Parameters
+      # Parameters {.doc-section .doc-section-parameters}
   
       | Name   | Type   | Description    | Default    |
       |--------|--------|----------------|------------|
       | `int`  |        | A description. | _required_ |
   
-      # Returns
+      # Returns {.doc-section .doc-section-returns}
   
       | Name   | Type   | Description    |
       |--------|--------|----------------|
       |        | int    | A description. |
   
-      # Attributes
+      # Attributes {.doc-section .doc-section-attributes}
   
       | Name   | Type   | Description    |
       |--------|--------|----------------|
       | int    |        | A description. |
   
   List
-      # Parameters
+      # Parameters {.doc-section .doc-section-parameters}
   
-      [`int`]{.parameter-name}[:]{.parameter-annotation-sep}[]{.parameter-annotation}[ = ]{.parameter-default-sep}
-  
-      :   A description.
-  
-      # Returns
-  
-      []{.parameter-name}[:]{.parameter-annotation-sep}[int]{.parameter-annotation}
+      <code>[`int`]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
       :   A description.
   
-      # Attributes
+      # Returns {.doc-section .doc-section-returns}
   
-      [int]{.parameter-name}[:]{.parameter-annotation-sep}[]{.parameter-annotation}
+      <code>[]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+  
+      :   A description.
+  
+      # Attributes {.doc-section .doc-section-attributes}
+  
+      <code>[int]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
       :   A description.
   '''
@@ -440,40 +440,40 @@
           A description.
   
   Default
-      # Parameters
+      # Parameters {.doc-section .doc-section-parameters}
   
       | Name   | Type   | Description    | Default    |
       |--------|--------|----------------|------------|
       | `name` |        | A description. | _required_ |
   
-      # Returns
+      # Returns {.doc-section .doc-section-returns}
   
       | Name   | Type   | Description    |
       |--------|--------|----------------|
       | name   | int    | A description. |
   
-      # Attributes
+      # Attributes {.doc-section .doc-section-attributes}
   
       | Name   | Type   | Description    |
       |--------|--------|----------------|
       | name   | int    | A description. |
   
   List
-      # Parameters
+      # Parameters {.doc-section .doc-section-parameters}
   
-      [`name`]{.parameter-name}[:]{.parameter-annotation-sep}[]{.parameter-annotation}[ = ]{.parameter-default-sep}
-  
-      :   A description.
-  
-      # Returns
-  
-      [name]{.parameter-name}[:]{.parameter-annotation-sep}[int]{.parameter-annotation}
+      <code>[`name`]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
       :   A description.
   
-      # Attributes
+      # Returns {.doc-section .doc-section-returns}
   
-      [name]{.parameter-name}[:]{.parameter-annotation-sep}[int]{.parameter-annotation}
+      <code>[name]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+  
+      :   A description.
+  
+      # Attributes {.doc-section .doc-section-attributes}
+  
+      <code>[name]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
   
       :   A description.
   '''

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -212,7 +212,7 @@ def test_render_doc_signature_name_alias_of_alias(snapshot, renderer):
 )
 def test_render_numpydoc_section_return(snapshot, doc):
     from quartodoc.parsers import get_parser_defaults
-    from griffe.docstrings.parsers import Parser
+    from griffe import Parser
 
     full_doc = (
         f"""Parameters\n---\n{doc}\n\nReturns\n---\n{doc}\n\nAttributes\n---\n{doc}"""

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -22,7 +22,7 @@ def test_render_param_kwargs(renderer):
     f = get_object("quartodoc.tests.example_signature.no_annotations")
     res = renderer.render(f.parameters)
 
-    assert res == "a, b=1, *args, c, d=2, **kwargs"
+    assert ", ".join(res) == "a, b=1, *args, c, d=2, **kwargs"
 
 
 def test_render_param_kwargs_annotated():
@@ -32,8 +32,8 @@ def test_render_param_kwargs_annotated():
     res = renderer.render(f.parameters)
 
     assert (
-        res
-        == "a: int, b: int = 1, *args: list\[str\], c: int, d: int, **kwargs: dict\[str, str\]"
+        ", ".join(res)
+        == "a: int, b: int = 1, *args: list[str], c: int, d: int, **kwargs: dict[str, str]"
     )
 
 
@@ -50,7 +50,7 @@ def test_render_param_kwonly(src, dst, renderer):
     f = get_object("quartodoc.tests", src)
 
     res = renderer.render(f.parameters)
-    assert res == dst
+    assert ", ".join(res) == dst
 
 
 @pytest.mark.parametrize(
@@ -108,7 +108,9 @@ def test_render_doc_attribute(renderer):
     res = renderer.render(attr)
     print(res)
 
-    assert res == ["abc", r"Optional\[\]", "xyz"]
+    assert res.name == "abc"
+    assert res.annotation == "Optional\[\]"
+    assert res.description == "xyz"
 
 
 def test_render_doc_section_admonition(renderer):

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -1,9 +1,16 @@
 import pytest
+from quartodoc._griffe_compat import dataclasses as dc
 from quartodoc._griffe_compat import docstrings as ds
 from quartodoc._griffe_compat import expressions as exp
 
 from quartodoc.renderers import MdRenderer
 from quartodoc import layout, get_object, blueprint, Auto
+
+from textwrap import indent
+
+
+def indented_sections(**kwargs: str):
+    return "\n\n".join([f"{k}\n" + indent(v, " " * 4) for k, v in kwargs.items()])
 
 
 @pytest.fixture
@@ -194,3 +201,32 @@ def test_render_doc_signature_name_alias_of_alias(snapshot, renderer):
     res = renderer.render(bp)
 
     assert res == snapshot
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        """name: int\n    A description.""",
+        """int\n    A description.""",
+    ],
+)
+def test_render_numpydoc_section_return(snapshot, doc):
+    from quartodoc.parsers import get_parser_defaults
+    from griffe.docstrings.parsers import Parser
+
+    full_doc = (
+        f"""Parameters\n---\n{doc}\n\nReturns\n---\n{doc}\n\nAttributes\n---\n{doc}"""
+    )
+
+    el = dc.Docstring(
+        value=full_doc, parser=Parser.numpy, parser_options=get_parser_defaults("numpy")
+    )
+
+    assert el.parsed is not None and len(el.parsed) == 3
+
+    res_default = MdRenderer().render(el)
+    res_list = MdRenderer(table_style="description-list").render(el)
+
+    assert snapshot == indented_sections(
+        Code=full_doc, Default=res_default, List=res_list
+    )


### PR DESCRIPTION
This PR implements description lists, based on the way [py-shiny](https://shiny.posit.co/py/api/ui.page_sidebar.html) and [plotnine](https://has2k1.github.io/plotnine/reference/) extended the renderer in their docs.

While in the Renderer, I'll work on...

* migrating to use the `quartodoc.pandoc` submodule.
* consolidate more header generation into the .render_header() method.
* planning out nice HTML classes, so it's easier to style everything

Backwards incompatible changes:

* `render(self, dc.Object | dc.Alias)` now calls `render(self, dc.Docstring)`, rather than iterating over the docstring itself.
  - This makes the printout of dc.Docstring renders in snapshot tests look a bit nicer. 

### HTML overview

Here's a rough sketch of the HTML structure rendered by quarto, using PUG:

```pug
// Doc example for quartodoc.MdRenderer
//
// Sections are automatically added around headers by quarto
// and we can add ids or classes to them
section.level1.quartodoc-MdRenderer.quartodoc(id='quartodoc.MdRenderer')

  // object title ----
  h1.quartodoc-MdRenderer.quartodoc MdRenderer

  // object signature ----
  p
    code
      | MdRenderer(self, header_level=1, show_signature=True ...)
  // doc section: short description ---
  p Render docstrings to markdown.

  // doc section: parameters ---
  section#parameters.level2.parameters
    h2.parameters.doc-section.doc-section-parameters.anchored(data-anchor-id='parameters')
      | Parameters
      a.anchorjs-link(...)

    // parameters definition list ---
    dl
      dt
        span.parameter-name
          code header_level
        span.parameter-annotation-sep :
        span.parameter-annotation
          a(href='https://docs.python.org/3/library/functions.html#int') int
        span.parameter-default-sep  =
        span.span-parameter-default
          code 1
      dd
        p The level of the header (e.g.&nbsp;1 is the biggest).

  // doc section: example ---
  section#examples.level2.examples
    h2.examples.doc-section.doc-section-examples.anchored(data-anchor-id='examples')
      | Examples
      a.anchorjs-link(...)
    #cb1.sourceCode
      pre.sourceCode.python.code-with-copy.
```

### TODO:

* Adding CSS styles to quartodoc sites (with description lists, you will need to add styles for them to look reasonable).
* Diagram