### PR TITLE
fix: do not exclude child methods on alias classes

### DIFF
--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -376,8 +376,15 @@ class BlueprintTransformer(PydanticTransformer):
         if not el.include_private:
             options = {k: v for k, v in options.items() if not k.startswith("_")}
 
-        if not (el.include_imports or el.include_inherited):
+        if not el.include_imports and obj.is_module:
             options = {k: v for k, v in options.items() if not v.is_alias}
+
+        if not el.include_inherited and obj.is_class:
+            # aliases are kept only if their parent is the current obj
+            # i.e. they do not belong to a parent class
+            options = {
+                k: v for k, v in options.items() if (v.parent is obj or not v.is_alias)
+            }
 
         # resolve any remaining aliases ----
         # the reamining filters require attributes on the target object.

--- a/quartodoc/tests/example_alias_target.py
+++ b/quartodoc/tests/example_alias_target.py
@@ -1,5 +1,6 @@
 from quartodoc.tests.example_alias_target__nested import (  # noqa: F401
     nested_alias_target,
+    NestedClass as ClassAlias,
     tabulate as external_alias,
 )
 

--- a/quartodoc/tests/example_alias_target__nested.py
+++ b/quartodoc/tests/example_alias_target__nested.py
@@ -7,3 +7,15 @@ from tabulate import tabulate  # noqa: F401
 
 def nested_alias_target():
     """A nested alias target"""
+
+
+class Parent:
+    def parent_method(self):
+        """p1 method"""
+
+
+class NestedClass(Parent):
+    def f(self):
+        """a method"""
+
+    manually_attached = nested_alias_target

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -98,6 +98,25 @@ def test_blueprint_visit_class(bp, dynamic):
 
 
 @pytest.mark.parametrize("dynamic", [False, True])
+def test_blueprint_visit_class_alias(bp, dynamic):
+    path = "quartodoc.tests.example_alias_target:ClassAlias"
+    auto = lo.Auto(name=path, dynamic=dynamic)
+    res = bp.visit(auto)
+
+    assert isinstance(res, lo.DocClass)
+
+    if not dynamic:
+        # currently, griffe doesn't know that the function manually attached
+        # to the class is a function, and not an attribute.
+        assert len(res.members) == 1
+        assert res.members[0].name == "f"
+    else:
+        assert len(res.members) == 2
+        assert res.members[0].name == "f"
+        assert res.members[1].name == "manually_attached"
+
+
+@pytest.mark.parametrize("dynamic", [False, True])
 def test_blueprint_visit_module(bp, dynamic):
     path = "quartodoc.tests.example"
     auto = lo.Auto(name=path, members=["a_func"], dynamic=dynamic)


### PR DESCRIPTION
Addresses #317 by ensuring we include methods defined in a class, even we are documenting an alias of that class.