### PR TITLE
dev: pin pytest<8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ ci = "https://github.com/machow/quartodoc/actions"
 
 
 [project.optional-dependencies]
-dev = ["pytest", "jupyterlab", "jupytext", "syrupy", "pre-commit"]
+dev = ["pytest<8.0.0", "jupyterlab", "jupytext", "syrupy", "pre-commit"]
 
 [project.scripts]
 quartodoc = "quartodoc.__main__:cli"


### PR DESCRIPTION
This is a temporary patch to fix CI runs. It pins pytest to be <8.0.0.

Seems like the long term fix is likely here:

https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#tests-as-part-of-application-code

Here is the error encountered on test collection:

```
_________________ ERROR collecting quartodoc/tests/test_ast.py _________________
import file mismatch:
imported module 'quartodoc.tests.test_ast' has this __file__ attribute:
  /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/quartodoc/tests/test_ast.py
which is not the same as the test file we want to collect:
  /home/runner/work/quartodoc/quartodoc/quartodoc/tests/test_ast.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
```