### PR TITLE
Fix Shinyswatch url in examples

### DIFF
--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -85,7 +85,7 @@ print(
         "images/shinyswatch-home.jpeg",
         "https://posit-dev.github.io/py-shinyswatch/",
         "Shinyswatch",
-        href_ref = "https://posit-dev.github.io/py-shinyswatch/",
+        href_ref = "https://posit-dev.github.io/py-shinyswatch/reference",
         href_source = "https://github.com/posit-dev/py-shinyswatch",
     ),
     gallery_entry_cta()

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -83,7 +83,7 @@ print(
     ),
     gallery_entry(
         "images/shinyswatch-home.jpeg",
-        "https://github.com/posit-dev/py-shinyswatch/",
+        "https://posit-dev.github.io/py-shinyswatch/",
         "Shinyswatch",
         href_ref = "https://posit-dev.github.io/py-shinyswatch/",
         href_source = "https://github.com/posit-dev/py-shinyswatch",

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -83,10 +83,10 @@ print(
     ),
     gallery_entry(
         "images/shinyswatch-home.jpeg",
-        "https://rstudio.github.io/py-shinyswatch/",
+        "https://github.com/posit-dev/py-shinyswatch/",
         "Shinyswatch",
-        href_ref = "https://rstudio.github.io/py-shinyswatch/reference",
-        href_source = "https://github.com/rstudio/py-shinyswatch",
+        href_ref = "https://posit-dev.github.io/py-shinyswatch/",
+        href_source = "https://github.com/posit-dev/py-shinyswatch",
     ),
     gallery_entry_cta()
   ])


### PR DESCRIPTION
Switch `Shinyswatch` from using `rstudio` to `posit-dev` to avoid a 404