### PR TITLE
docs: use fast interlinks

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -6,6 +6,7 @@ project:
     - examples/pkgdown
     - examples/auto-package
     - objects.txt
+    - objects-test.txt
 
 metadata-files:
   - api/_sidebar.yml

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -21,6 +21,9 @@ interlinks:
       url: https://docs.python.org/3/
     griffe:
       url: https://mkdocstrings.github.io/griffe/
+    qd2:
+      url: https://pr-350--quartodoc.netlify.app/
+      inv: objects-test.txt
 
 
 website:

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -5,6 +5,7 @@ project:
     - examples/single-page
     - examples/pkgdown
     - examples/auto-package
+    - objects.txt
 
 metadata-files:
   - api/_sidebar.yml
@@ -13,11 +14,13 @@ filters:
   - "interlinks"
 
 interlinks:
+  fast: true
   sources:
     python:
       url: https://docs.python.org/3/
     griffe:
       url: https://mkdocstrings.github.io/griffe/
+
 
 website:
   title: "quartodoc"

--- a/docs/get-started/interlinks.qmd
+++ b/docs/get-started/interlinks.qmd
@@ -185,3 +185,7 @@ For an overview of the sphinx inventory format, see [the sphobjinv docs](https:/
 
 The rough idea is that this plugin will behave similar to [jupyterbook linking](https://jupyterbook.org/en/stable/content/references.html),
 which supports both some intersphinx syntax, but also markdown syntax.
+
+## Test interlinks cross site
+
+[](`qd2.Auto`)

--- a/docs/get-started/interlinks.qmd
+++ b/docs/get-started/interlinks.qmd
@@ -43,6 +43,9 @@ interlinks:
       url: https://numpy.org/doc/stable/
     python:
       url: https://docs.python.org/3/
+    quartodoc-test:
+      url: https://machow.github.io/quartodoc
+      inv: objects-test.txt
 ```
 
 Notice 2 important pieces in this config:
@@ -50,9 +53,11 @@ Notice 2 important pieces in this config:
 * The `numpy` and `python` fields indicate that we're getting inventories for the
   library numpy, and python builtin libraries.
 * The `url` fields indicate where inventory files can be found.
+* The `inv` field lets you specify the name of the inventory file. By default, it assumes its `objects.inv`.
 
 By default, downloaded inventory files will be saved in the `_inv` folder of your
 documentation directory.
+
 
 ### Experimental fast option
 
@@ -175,6 +180,9 @@ Most sphinx sites name them `object.inv`:
 See the [sphobjinv docs](https://sphobjinv.readthedocs.io/en/stable/) for thorough
 details on these files, and how they're used in sphinx.
 
+:::{.callout-note}
+[objects-test.txt](https://github.com/machow/quartodoc/tree/main/docs/objects-test.txt) is an example file with one entry: [](`qd2.Auto`).
+:::
 
 ## More information
 
@@ -185,7 +193,3 @@ For an overview of the sphinx inventory format, see [the sphobjinv docs](https:/
 
 The rough idea is that this plugin will behave similar to [jupyterbook linking](https://jupyterbook.org/en/stable/content/references.html),
 which supports both some intersphinx syntax, but also markdown syntax.
-
-## Test interlinks cross site
-
-[](`qd2.Auto`)

--- a/docs/objects-test.txt
+++ b/docs/objects-test.txt
@@ -1,0 +1,5 @@
+# Sphinx inventory version 2
+# Project: quartodoc
+# Version: 0.0.9999
+# The remainder of this file is compressed using zlib.
+qd2.Auto py:class 1 api/Auto.html#quartodoc.Auto -

--- a/quartodoc/__main__.py
+++ b/quartodoc/__main__.py
@@ -12,6 +12,7 @@ from functools import partial
 from watchdog.events import PatternMatchingEventHandler
 from quartodoc import Builder, convert_inventory
 from ._pydantic_compat import BaseModel
+from .interlinks import inventory_from_url
 
 
 def get_package_path(package_name):
@@ -258,7 +259,8 @@ def interlinks(config, dry_run, fast):
             continue
 
         url = v["url"] + v.get("inv", "objects.inv")
-        inv = soi.Inventory(url=url)
+
+        inv = inventory_from_url(url)
 
         p_dst = p_root / cache / f"{k}_objects"
         p_dst.parent.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
This PR provides a fix that allows a quartodoc site to use the objects.txt file generated by another site. an objects.txt file is an unzipped version of objects.inv, and is also [supported by sphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration). 

~Blocked by: https://github.com/quarto-dev/quarto-cli/issues/10021~ I'm just going to push it since it should only be an issue on preview branches.