### PR TITLE
chore(deps): add missing requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "importlib-resources >= 5.10.2",
     "pydantic",
     "pyyaml",
+    "requests",
     "typing-extensions >= 4.4.0",
     "watchdog >= 3.0.0",
     "plum-dispatch < 2.0.0; python_version < '3.10'",


### PR DESCRIPTION
requests is being imported in `interlinks.py` in the latest release but it isn't listed as a dependency
