### PR TITLE
fix: support griffe v1, and backwards compat to v0.37.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # Checks based on python versions ---
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
         requirements: [""]
 
         include:
@@ -43,7 +43,11 @@ jobs:
           REQUIREMENTS: ${{ matrix.requirements }}
       - name: Run tests
         run: |
-          pytest
+          pytest --cov
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:
     name: "pre-commit checks"
@@ -55,8 +59,8 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - name: Install dev dependencies
         run: |
-            python -m pip install --upgrade pip
-            python -m pip install ".[dev]"
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
       - uses: pre-commit/action@v3.0.0
 
   release-pypi:
@@ -100,7 +104,6 @@ jobs:
         run: |
           make docs-build
       # push to netlify -------------------------------------------------------
-
       # set release name ----
 
       - name: Configure pull release name
@@ -115,7 +118,6 @@ jobs:
           # use branch name, but replace slashes. E.g. feat/a -> feat-a
           echo "RELEASE_NAME=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
       # deploy ----
-
       - name: Create Github Deployment
         uses: bobheadxi/deployments@v0.4.3
         id: deployment
@@ -125,7 +127,7 @@ jobs:
           env: ${{ env.RELEASE_NAME }}
           ref: ${{ github.head_ref }}
           transient: true
-          logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          logs: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Netlify docs preview
         run: |
@@ -149,8 +151,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: 'https://${{ steps.deployment.outputs.env }}--quartodoc.netlify.app'
-          logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          env_url: "https://${{ steps.deployment.outputs.env }}--quartodoc.netlify.app"
+          logs: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - uses: peaceiris/actions-gh-pages@v3
         if: github.event_name == 'release'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,6 @@ jobs:
           python -m pip install shiny shinylive
           python -m pip install --no-deps dascore==0.0.8
       - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: "1.2.475"
       - name: Build docs
         run: |
           make docs-build

--- a/case_studies/parsing.qmd
+++ b/case_studies/parsing.qmd
@@ -55,12 +55,12 @@ res["objects"][0]["children"]["some_package"]["children"]
 ## Running griffe
 
 ```{python}
-from griffe.loader import GriffeLoader
-from griffe.docstrings.parsers import Parser, parse
+from griffe import GriffeLoader
+from griffe import Parser, parse
 
-griffe = GriffeLoader()
+loader = GriffeLoader()
 
-sb2 = griffe.load_module("some_package")
+sb2 = loader.load("some_package")
 
 parse(sb2.functions["some_function"].docstring, Parser.numpy)
 ```

--- a/docs/get-started/basic-content.qmd
+++ b/docs/get-started/basic-content.qmd
@@ -66,14 +66,14 @@ By default, all attributes and functions (including methods on a class) are pres
 There are four styles for presenting child members:
 
 ```{python}
-#| echo: false
-#| output: asis
+# | echo: false
+# | output: asis
 
-# print out the attributes table of ChoicesChildren 
+# print out the attributes table of ChoicesChildren
 # this is overkill, but maybe a nice case of dogfooding
 from quartodoc import get_object, MdRenderer
 from quartodoc.builder.utils import extract_type
-from griffe.docstrings.dataclasses import DocstringSectionAttributes
+from griffe import DocstringSectionAttributes
 
 renderer = MdRenderer()
 choices = get_object("quartodoc.layout.ChoicesChildren")
@@ -420,12 +420,12 @@ Below is a summary of all the options that can be applied to individual content 
 
 
 ```{python}
-#| echo: false
-#| output: asis
+# | echo: false
+# | output: asis
 
 from quartodoc import get_object, MdRenderer, Auto
 from quartodoc.builder.utils import extract_type
-from griffe.docstrings.dataclasses import DocstringSectionAttributes
+from griffe import DocstringSectionAttributes
 
 renderer = MdRenderer()
 choices = get_object("quartodoc.Auto")

--- a/docs/get-started/dev-renderers.qmd
+++ b/docs/get-started/dev-renderers.qmd
@@ -57,18 +57,19 @@ types of objects.
 ```{python}
 from plum import dispatch
 
-import griffe.dataclasses as dc
-import griffe.docstrings.dataclasses as ds
+from griffe import Alias, Object, Docstring
 
 
 @dispatch
 def render(el: object):
     print(f"Default rendering: {type(el)}")
 
+
 @dispatch
-def render(el: dc.Alias):
+def render(el: Alias):
     print("Alias rendering")
     render(el.parameters)
+
 
 @dispatch
 def render(el: list):
@@ -85,8 +86,7 @@ quartodoc uses tree visitors to render parsed docstrings to formats like markdow
 Tree visitors define how each type of object in the parse tree should be handled.
 
 ```{python}
-import griffe.dataclasses as dc
-import griffe.docstrings.dataclasses as ds
+from griffe import Alias, Object, Docstring
 
 from quartodoc import get_object
 from plum import dispatch
@@ -102,17 +102,17 @@ class SomeRenderer:
         raise NotImplementedError(f"Unsupported type: {type(el)}")
 
     @dispatch
-    def render(self, el: Union[dc.Alias, dc.Object]):
+    def render(self, el: Union[Alias, Object]):
         header = "#" * self.header_level
         str_header = f"{header} {el.name}"
         str_params = f"N PARAMETERS: {len(el.parameters)}"
         str_sections = "SECTIONS: " + self.render(el.docstring)
-        
+
         # return something pretty
         return "\n".join([str_header, str_params, str_sections])
 
     @dispatch
-    def render(self, el: dc.Docstring):
+    def render(self, el: Docstring):
         return f"A docstring with {len(el.parsed)} pieces"
 
 

--- a/docs/get-started/extending.qmd
+++ b/docs/get-started/extending.qmd
@@ -40,7 +40,7 @@ Then, create the file `reference/index.qmd` to have the form:
 Some custom content.
 
 
-{{< include /reference/_api_index.qmd >}}
+{{{< include /reference/_api_index.qmd >}}}
 
 
 More content stuff.

--- a/docs/get-started/sidebar.qmd
+++ b/docs/get-started/sidebar.qmd
@@ -27,6 +27,6 @@ Here is what the sidebar for the [quartodoc reference page](/api) looks like:
 
 <div class="sourceCode">
 <pre class="sourceCode yaml"><code class="sourceCode yaml">
-{{< include /api/_sidebar.yml >}}
+{{{< include /api/_sidebar.yml >}}}
 </code></pre>
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,14 @@ ci = "https://github.com/machow/quartodoc/actions"
 
 
 [project.optional-dependencies]
-dev = ["pytest<8.0.0", "jupyterlab", "jupytext", "syrupy", "pre-commit"]
+dev = [
+    "pytest<8.0.0",
+    "pytest-cov",
+    "jupyterlab",
+    "jupytext",
+    "syrupy",
+    "pre-commit"
+]
 
 [project.scripts]
 quartodoc = "quartodoc.__main__:cli"

--- a/quartodoc/_griffe_compat.py
+++ b/quartodoc/_griffe_compat.py
@@ -1,0 +1,22 @@
+# flake8: noqa
+
+try:
+    from griffe import GriffeLoader
+    from griffe import ModulesCollection, LinesCollection
+
+    import _griffe.models as dataclasses
+    import _griffe.docstrings.models as docstrings
+    import _griffe.expressions as expressions
+
+    from griffe import Parser, parse, parse_numpy
+    from griffe import AliasResolutionError
+except ImportError:
+    from griffe.loader import GriffeLoader
+    from griffe.collections import ModulesCollection, LinesCollection
+
+    import griffe.dataclasses as dataclasses
+    import griffe.docstrings.dataclasses as docstrings
+    import griffe.expressions as expressions
+
+    from griffe.docstrings.parsers import Parser, parse
+    from griffe.exceptions import AliasResolutionError

--- a/quartodoc/ast.py
+++ b/quartodoc/ast.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import warnings
 
+from ._griffe_compat import docstrings as ds
+from ._griffe_compat import dataclasses as dc
+
 from enum import Enum
 from dataclasses import dataclass
-from griffe.docstrings import dataclasses as ds
-from griffe import dataclasses as dc
 from plum import dispatch
 from typing import Type, Union
 

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -4,11 +4,15 @@ import logging
 import json
 import yaml
 
-from griffe import dataclasses as dc
-from griffe.loader import GriffeLoader
-from griffe.collections import ModulesCollection, LinesCollection
-from griffe.docstrings.parsers import Parser
-from griffe.exceptions import AliasResolutionError
+from .._griffe_compat import dataclasses as dc
+from .._griffe_compat import (
+    GriffeLoader,
+    ModulesCollection,
+    LinesCollection,
+    Parser,
+)
+
+from .._griffe_compat import AliasResolutionError
 from functools import partial
 from textwrap import indent
 
@@ -43,7 +47,7 @@ if TYPE_CHECKING:
 def _auto_package(mod: dc.Module) -> list[Section]:
     """Create default sections for the given package."""
 
-    import griffe.docstrings.dataclasses as ds
+    from quartodoc._griffe_compat import docstrings as ds
 
     has_all = "__all__" in mod.members
 

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -67,7 +67,7 @@ def _auto_package(mod: dc.Module) -> list[Section]:
             external_alias
             or member.is_module
             or name.startswith("__")
-            or (has_all and not mod.member_is_exported(member))
+            or (has_all and not mod.is_exported(member))
         ):
             continue
 

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -67,7 +67,7 @@ def _auto_package(mod: dc.Module) -> list[Section]:
             external_alias
             or member.is_module
             or name.startswith("__")
-            or (has_all and not mod.is_exported(member))
+            or (has_all and not member.is_exported)
         ):
             continue
 

--- a/quartodoc/inventory.py
+++ b/quartodoc/inventory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sphobjinv as soi
 
-from griffe import dataclasses as dc
+from ._griffe_compat import dataclasses as dc
 from plum import dispatch
 from quartodoc import layout
 

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import griffe.dataclasses as dc
+from ._griffe_compat import dataclasses as dc
 import logging
 
 from enum import Enum

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -4,9 +4,9 @@ import quartodoc.ast as qast
 
 from contextlib import contextmanager
 from functools import wraps
-from griffe.docstrings import dataclasses as ds
-from griffe import dataclasses as dc
-from griffe import expressions as expr
+from .._griffe_compat import docstrings as ds
+from .._griffe_compat import dataclasses as dc
+from .._griffe_compat import expressions as expr
 from tabulate import tabulate
 from plum import dispatch
 from typing import Tuple, Union, Optional
@@ -152,8 +152,6 @@ class MdRenderer(Renderer):
         self.display_name = orig
 
         return res
-
-
 
     @dispatch
     def signature(self, el: dc.Alias, source: Optional[dc.Alias] = None):
@@ -335,14 +333,14 @@ class MdRenderer(Renderer):
                         [self.render(x) for x in raw_meths if isinstance(x, layout.Doc)]
                     )
 
-
         str_sig = self.signature(el)
         sig_part = [str_sig] if self.show_signature else []
 
         body = self.render(el.obj)
 
-
-        return "\n\n".join([title, *sig_part, body, *attr_docs, *class_docs, *meth_docs])
+        return "\n\n".join(
+            [title, *sig_part, body, *attr_docs, *class_docs, *meth_docs]
+        )
 
     @dispatch
     def render(self, el: Union[layout.DocFunction, layout.DocAttribute]):

--- a/quartodoc/tests/test_ast.py
+++ b/quartodoc/tests/test_ast.py
@@ -1,9 +1,9 @@
 import quartodoc.ast as qast
 import pytest
 
-from griffe.docstrings import dataclasses as ds
-from griffe import dataclasses as dc
-from griffe.docstrings.parsers import parse_numpy
+from quartodoc._griffe_compat import docstrings as ds
+from quartodoc._griffe_compat import dataclasses as dc
+from quartodoc._griffe_compat import parse_numpy
 
 from quartodoc import get_object
 

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -1,8 +1,8 @@
 import pytest
 
 from quartodoc import get_object, get_function, MdRenderer
-from griffe.docstrings import dataclasses as ds
-from griffe import dataclasses as dc
+from quartodoc._griffe_compat import docstrings as ds
+from quartodoc._griffe_compat import dataclasses as dc
 
 # TODO: rename to test_autosummary (or refactor autosummary into parts)
 

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -1,5 +1,5 @@
 from functools import partial
-from griffe.exceptions import AliasResolutionError
+from quartodoc._griffe_compat import AliasResolutionError
 from quartodoc import get_object
 from quartodoc import layout as lo
 from quartodoc.builder.blueprint import (

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -1,6 +1,6 @@
 import pytest
-import griffe.docstrings.dataclasses as ds
-import griffe.expressions as exp
+from quartodoc._griffe_compat import docstrings as ds
+from quartodoc._griffe_compat import expressions as exp
 
 from quartodoc.renderers import MdRenderer
 from quartodoc import layout, get_object, blueprint, Auto


### PR DESCRIPTION
This PR adds support for griffe v1, by attempting to do v1-centered imports. If that fails, it falls back to imports that expect griffe < v1.

Note that auto package functionality requires griffe > v0.46.0, which renamed `member_is_exported` to `is_exported`.