### PR TITLE
tests: get_object returns annotations from pyi stub files

### DIFF
--- a/quartodoc/tests/example_stubs.py
+++ b/quartodoc/tests/example_stubs.py
@@ -1,0 +1,2 @@
+def f(a, b):
+    """The original docstring."""

--- a/quartodoc/tests/example_stubs.pyi
+++ b/quartodoc/tests/example_stubs.pyi
@@ -1,0 +1,2 @@
+def f(a: int, b: str):
+    """The stub docstring"""

--- a/quartodoc/tests/test_basic.py
+++ b/quartodoc/tests/test_basic.py
@@ -56,6 +56,11 @@ def test_render_attribute():
     assert MdRenderer().render(a) == "I am an attribute docstring"
 
 
+def test_get_object_stub_pyi():
+    obj = get_object("quartodoc.tests.example_stubs:f")
+    assert obj.parameters[0].annotation.name == "int"
+
+
 def test_get_object_dynamic_module_root():
     obj = get_object("quartodoc", dynamic=True)
     assert isinstance(obj, dc.Module)


### PR DESCRIPTION
This PR verifies that quartodoc loads type annotations from stub files (.pyi) when present. Note that this may require a specific version of griffe, like v1+ (which is doing all the heavy lifting ;)