### PR TITLE
fix: missing branch in show_signature_annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "${{ matrix.python-version }}"
+          python-version: "3.10"
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -539,6 +539,9 @@ class MdRenderer(Renderer):
                 res = f"{glob}{name}: {annotation} = {el.default}"
             elif annotation:
                 res = f"{glob}{name}: {annotation}"
+            else:
+                res = f"{glob}{name}"
+
         elif has_default:
             res = f"{glob}{name}={el.default}"
         else:

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -7,15 +7,17 @@
   tests.example_signature.a_complex_signature(
       x: list[C | int | None]
       y: pathlib.Pathlib
+      z
   )
   ```
   
   ## Parameters {.doc-section .doc-section-parameters}
   
-  | Name   | Type                                                                                 | Description     | Default    |
-  |--------|--------------------------------------------------------------------------------------|-----------------|------------|
-  | x      | [list](`list`)\[[C](`quartodoc.tests.example_signature.C`) \| [int](`int`) \| None\] | The x parameter | _required_ |
-  | y      | [pathlib](`pathlib`).[Pathlib](`pathlib.Pathlib`)                                    | The y parameter | _required_ |
+  | Name   | Type                                                                                 | Description                   | Default    |
+  |--------|--------------------------------------------------------------------------------------|-------------------------------|------------|
+  | x      | [list](`list`)\[[C](`quartodoc.tests.example_signature.C`) \| [int](`int`) \| None\] | The x parameter               | _required_ |
+  | y      | [pathlib](`pathlib`).[Pathlib](`pathlib.Pathlib`)                                    | The y parameter               | _required_ |
+  | z      |                                                                                      | The z parameter (unannotated) | _required_ |
   '''
 # ---
 # name: test_render_annotations_complex_no_interlinks
@@ -26,15 +28,17 @@
   tests.example_signature.a_complex_signature(
       x: list[C | int | None]
       y: pathlib.Pathlib
+      z
   )
   ```
   
   ## Parameters {.doc-section .doc-section-parameters}
   
-  | Name   | Type                     | Description     | Default    |
-  |--------|--------------------------|-----------------|------------|
-  | x      | list\[C \| int \| None\] | The x parameter | _required_ |
-  | y      | pathlib.Pathlib          | The y parameter | _required_ |
+  | Name   | Type                     | Description                   | Default    |
+  |--------|--------------------------|-------------------------------|------------|
+  | x      | list\[C \| int \| None\] | The x parameter               | _required_ |
+  | y      | pathlib.Pathlib          | The y parameter               | _required_ |
+  | z      |                          | The z parameter (unannotated) | _required_ |
   '''
 # ---
 # name: test_render_doc_class[embedded]

--- a/quartodoc/tests/example_signature.py
+++ b/quartodoc/tests/example_signature.py
@@ -31,7 +31,7 @@ class C:
     ...
 
 
-def a_complex_signature(x: "list[C | int | None]", y: "pathlib.Pathlib"):
+def a_complex_signature(x: "list[C | int | None]", y: "pathlib.Pathlib", z):
     """
     Parameters
     ----------
@@ -39,4 +39,6 @@ def a_complex_signature(x: "list[C | int | None]", y: "pathlib.Pathlib"):
         The x parameter
     y:
         The y parameter
+    z:
+        The z parameter (unannotated)
     """


### PR DESCRIPTION
This PR addresses #361 by adding a missing branch, when rendering annotations. (~TODO: add a test~)