### PR TITLE
fix: use shortname for member children linked style

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -768,7 +768,7 @@ class MdRenderer(Renderer):
     @dispatch
     def summarize(self, el: layout.Link):
         description = self.summarize(el.obj)
-        return self._summary_row(f"[](`{el.name}`)", description)
+        return self._summary_row(f"[](`~{el.name}`)", description)
 
     @dispatch
     def summarize(self, obj: Union[dc.Object, dc.Alias]) -> str:

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -314,6 +314,33 @@
   A function
   '''
 # ---
+# name: test_render_doc_module[linked]
+  '''
+  # quartodoc.tests.example { #quartodoc.tests.example }
+  
+  `tests.example`
+  
+  A module
+  
+  ## Attributes
+  
+  | Name | Description |
+  | --- | --- |
+  | [](`~quartodoc.tests.example.a_attr`) | An attribute |
+  
+  ## Classes
+  
+  | Name | Description |
+  | --- | --- |
+  | [](`~quartodoc.tests.example.AClass`) | A class |
+  
+  ## Functions
+  
+  | Name | Description |
+  | --- | --- |
+  | [](`~quartodoc.tests.example.a_func`) | A function |
+  '''
+# ---
 # name: test_render_doc_signature_name
   '''
   # example.a_func { #quartodoc.tests.example.a_func }

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -126,7 +126,7 @@ def test_render_doc_section_admonition(renderer):
     assert res == "quartodoc.tests.example: Method for doing a thing"
 
 
-@pytest.mark.parametrize("children", ["embedded", "flat"])
+@pytest.mark.parametrize("children", ["embedded", "flat", "linked"])
 def test_render_doc_module(snapshot, renderer, children):
     bp = blueprint(Auto(name="quartodoc.tests.example", children=children))
     res = renderer.render(bp)


### PR DESCRIPTION
This PR addresses https://github.com/machow/quartodoc/issues/150 by shortening the names shown for interlinks when using `children: linked`.