### PR TITLE
feat: Add `sidebar_options` for configuring the sidebar

### DIFF
--- a/docs/get-started/sidebar.qmd
+++ b/docs/get-started/sidebar.qmd
@@ -19,9 +19,20 @@ quartodoc:
 ```
 
 Note that running `python -m quartodoc build` will now produce a file called `_sidebar.yml`,
-with a [quarto sidebar configuration](https://quarto.org/docs/websites/website-navigation.html#side-navigation).
-The quarto [`metadata-files` option](https://quarto.org/docs/projects/quarto-projects.html#metadata-includes) ensures
+with a [Quarto sidebar configuration](https://quarto.org/docs/websites/website-navigation.html#side-navigation).
+The Quarto [`metadata-files` option](https://quarto.org/docs/projects/quarto-projects.html#metadata-includes) ensures
 it's included with the configuration in `_quarto.yml`.
+
+Additional [sidebar options are available in Quarto](https://quarto.org/docs/websites/website-navigation.html#side-navigation) and can be passed from quartodoc to Quarto via `sidebar_options`:
+
+```yaml
+quartodoc:
+  sidebar: "_sidebar.yml"
+  sidebar_options:
+    style: docked
+    search: true
+    collapse-level: 2
+```
 
 Here is what the sidebar for the [quartodoc reference page](/api) looks like:
 

--- a/docs/get-started/sidebar.qmd
+++ b/docs/get-started/sidebar.qmd
@@ -26,7 +26,6 @@ it's included with the configuration in `_quarto.yml`.
 Here is what the sidebar for the [quartodoc reference page](/api) looks like:
 
 <div class="sourceCode">
-<pre class="sourceCode yaml"><code class="sourceCode yaml">
-{{{< include /api/_sidebar.yml >}}}
+<pre class="sourceCode yaml"><code class="sourceCode yaml">{{< include /api/_sidebar.yml >}}
 </code></pre>
 </div>

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -427,6 +427,10 @@ class Builder:
         The output path of the index file, used to list all API functions.
     sidebar:
         The output path for a sidebar yaml config (by default no config generated).
+    sidebar_options:
+        Additional options to be included in the sidebar definition. See
+        [Side navigation](https://quarto.org/docs/websites/website-navigation.html#side-navigation)
+        in Quarto's documentation for more information.
     css:
         The output path for the default css styles.
     rewrite_all_pages:
@@ -488,6 +492,7 @@ class Builder:
         renderer: "dict | Renderer | str" = "markdown",
         out_index: str = None,
         sidebar: "str | None" = None,
+        sidebar_options: "dict | None" = None,
         css: "str | None" = None,
         rewrite_all_pages=False,
         source_dir: "str | None" = None,
@@ -505,6 +510,7 @@ class Builder:
         self.dir = dir
         self.title = title
         self.sidebar = sidebar
+        self.sidebar_options = sidebar_options
         self.css = css
         self.parser = parser
 
@@ -589,7 +595,7 @@ class Builder:
 
         if self.sidebar:
             _log.info(f"Writing sidebar yaml to {self.sidebar}")
-            self.write_sidebar(blueprint)
+            self.write_sidebar(blueprint, self.sidebar_options)
 
         # css ----
 
@@ -659,7 +665,7 @@ class Builder:
 
     # sidebar ----
 
-    def _generate_sidebar(self, blueprint: layout.Layout):
+    def _generate_sidebar(self, blueprint: layout.Layout, options: "dict | None" = None):
         contents = [f"{self.dir}/index{self.out_page_suffix}"]
         in_subsection = False
         crnt_entry = {}
@@ -686,7 +692,11 @@ class Builder:
         if crnt_entry:
             contents.append(crnt_entry)
 
-        entries = [{"id": self.dir, "contents": contents}, {"id": "dummy-sidebar"}]
+        # Create sidebar with user options, ensuring we control `id` and `contents`
+        sidebar = {**(self.sidebar_options or {})}
+        sidebar.update({"id": self.dir, "contents": contents})
+
+        entries = [sidebar,  {"id": "dummy-sidebar"}]
         return {"website": {"sidebar": entries}}
 
     def write_sidebar(self, blueprint: layout.Layout):

--- a/quartodoc/tests/__snapshots__/test_builder.ambr
+++ b/quartodoc/tests/__snapshots__/test_builder.ambr
@@ -18,3 +18,24 @@
   
   '''
 # ---
+# name: test_builder_generate_sidebar_options
+  '''
+  website:
+    sidebar:
+    - contents:
+      - reference/index.qmd
+      - contents:
+        - reference/a_func.qmd
+        section: first section
+      - contents:
+        - contents:
+          - reference/a_attr.qmd
+          section: a subsection
+        section: second section
+      id: reference
+      search: true
+      style: docked
+    - id: dummy-sidebar
+  
+  '''
+# ---

--- a/quartodoc/tests/test_builder.py
+++ b/quartodoc/tests/test_builder.py
@@ -82,3 +82,30 @@ def test_builder_generate_sidebar(tmp_path, snapshot):
     d_sidebar = builder._generate_sidebar(bp)
 
     assert yaml.dump(d_sidebar) == snapshot
+
+def test_builder_generate_sidebar_options(tmp_path, snapshot):
+    cfg = yaml.safe_load(
+        """
+    quartodoc:
+      package: quartodoc.tests.example
+      sidebar_options:
+        style: docked
+        search: true
+      sections:
+        - title: first section
+          desc: some description
+          contents: [a_func]
+        - title: second section
+          desc: title description
+        - subtitle: a subsection
+          desc: subtitle description
+          contents:
+            - a_attr
+    """
+    )
+
+    builder = Builder.from_quarto_config(cfg)
+    bp = blueprint(builder.layout)
+    d_sidebar = builder._generate_sidebar(bp)
+
+    assert yaml.dump(d_sidebar) == snapshot


### PR DESCRIPTION
Currently, (AFAICT) it's not possible to configure the sidebar generated by quartodoc.

This PR adds support `quartodoc.sidebar_options` which is then added to the `id` and `contents` created by quartodoc.

```yaml
quartodoc:
  package: quartodoc.tests.example
  sidebar: _reference.yml
  sidebar_options:
    style: docked
    search: true
```

This approach keeps sidebar options orthogonal to whatever choices about `sidebar` that quartodoc makes. It also ensures that `id` and `contents` are wholly controlled by quartodoc.

## Another option

Depending on how you feel about `sidebar_options`, I could certainly see a world where all of this is consolidated in `sidebar`, where we'd take all of the quarto options, plus an additional field like `file` for the yaml file name. Backwards compat would be possible by taking the string value

```yaml
quartodoc:
  sidebar: "_my-pkg.yml"
```

and automatically expanding to a full dictionary equivalent to

```yaml
quartodoc:
  sidebar:
    file: "_my-pkg.yml"
```

I think conceptually this is a bit nicer, but there's a small risk that we choose a field name for the sidebar filename that Quarto later chooses to add to `website.sidebar`. In this world, the first example would become something like this:

```yaml
quartodoc:
  package: quartodoc.tests.example
  sidebar: 
    file: _reference.yml
    style: docked
    search: true
```

If done this way, we could also let users choose `id` and customize `contents`. `id` is easily overwritten, but for `contents` we'd have to have a way to signal where the quartodoc contents should go.

My proposal for `contents` in this scenario would be to use a placeholder value to signal where to put quartodoc's contents, following these rules:

1. If no `contents`, use quartodoc's contents.
2. If `contents` and no sentinel value, append quartodoc's contents.
3. Place quartodoc's contents in a content item that matches `{{ contents }}`.

If you like this proposal, I don't think it would take long to rework this PR.