### PR TITLE
feat(Builder): Ignore unknown quartodoc options

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -444,7 +444,8 @@ class Builder:
     parser:
         Docstring parser to use. This correspond to different docstring styles,
         and can be one of "google", "sphinx", and "numpy". Defaults to "numpy".
-
+    kwargs:
+        Additional options are ignored with a warning for forwards compatibility.
     """
 
     # builder dispatching ----
@@ -495,6 +496,7 @@ class Builder:
         parser="numpy",
         render_interlinks: bool = False,
         _fast_inventory=False,
+        **kwargs: Any
     ):
         self.layout = self.load_layout(
             sections=sections, package=package, options=options
@@ -507,6 +509,13 @@ class Builder:
         self.sidebar = sidebar
         self.css = css
         self.parser = parser
+
+        if len(kwargs) > 0:
+            ignored_keys = [f"'{k}'" for k in kwargs.keys()]
+            text_options = "option" if len(kwargs) == 1 else "options"
+            warnings.warn(
+                f"Ignoring unknown quartodoc {text_options} {', '.join(ignored_keys)}"
+            )
 
         self.renderer = Renderer.from_config(renderer)
         if render_interlinks:


### PR DESCRIPTION
Rather than throwing an error to allow for backwards-compatible future expansion of quartodoc options.

In #370 I noticed that adding a new quartodoc option would make the `_quarto.yml` file automatically incompatible with older versions of quartodoc. I think it's reasonable to ignore extra options with a warning.