### PR TITLE
feat: add Auto member_order option

### DIFF
--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -407,7 +407,12 @@ class BlueprintTransformer(PydanticTransformer):
         if not el.include_functions:
             options = {k: v for k, v in options.items() if not v.is_function}
 
-        return sorted(options)
+        if el.member_order == "alphabetical":
+            return sorted(options)
+        elif el.member_order == "source":
+            return list(options)
+        else:
+            raise ValueError(f"Unsupported value of member_order: {el.member_order}")
 
 
 class _PagePackageStripper(PydanticTransformer):

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -225,6 +225,7 @@ class AutoOptions(_Base):
     dynamic: Union[None, bool, str] = None
     children: ChoicesChildren = ChoicesChildren.embedded
     package: Union[str, None, MISSING] = MISSING()
+    member_order: Literal["alphabetical", "source"] = "alphabetical"
     member_options: Optional["AutoOptions"] = None
 
     # for tracking fields users manually specify
@@ -275,6 +276,9 @@ class Auto(AutoOptions):
         Style for presenting members. Either separate, embedded, or flat.
     package:
         If specified, object lookup will be relative to this path.
+    member_order:
+        Order to present members in, either "alphabetical" or "source" order.
+        Defaults to alphabetical sorting.
     member_options:
         Options to apply to members. These can include any of the options above.
 

--- a/quartodoc/tests/test_builder_blueprint.py
+++ b/quartodoc/tests/test_builder_blueprint.py
@@ -260,6 +260,25 @@ def test_blueprint_fetch_members_dynamic():
     assert bp.members[0].obj.parent.path == name.replace(":", ".")
 
 
+@pytest.mark.parametrize("order", ["alphabetical", "source"])
+def test_blueprint_member_order(order):
+    auto = lo.Auto(
+        name="quartodoc.tests.example_class.C",
+        member_order=order,
+        include_functions=True,
+        include_attributes=False,
+        include_classes=False,
+    )
+    bp = blueprint(auto)
+    src_names = [entry.name for entry in bp.members]
+    dst_names = ["some_method", "some_class_method"]
+
+    if order == "alphabetical":
+        dst_names = sorted(dst_names)
+
+    assert src_names == dst_names
+
+
 def test_blueprint_member_options():
     auto = lo.Auto(
         name="quartodoc.tests.example",


### PR DESCRIPTION
This PR adds a `member_order` argument to Auto that decides how members should be sorted. There are two options:

* `"alphabetical"`: sorted alphabetically (e.g. a first, z last)
* `"source"`: in order they appear in the source code
