### PR TITLE
fix: parameter description list do not render None as default

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -77,7 +77,7 @@ class ParamRow:
         # in the table display format, not description lists....
         # by this stage _required_ is basically a special token to indicate
         # a required argument.
-        if default is not None:
+        if self.default is not None:
             part_default_sep = Span(" = ", Attr(classes=["parameter-default-sep"]))
             part_default = Span(default, Attr(classes=["parameter-default"]))
         else:

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -59,7 +59,7 @@ class ParamRow:
     def to_definition_list(self):
         name = self.name
         anno = self.annotation
-        desc = self.description
+        desc = sanitize(self.description, allow_markdown=True)
         default = sanitize(str(self.default))
 
         part_name = (
@@ -100,13 +100,15 @@ class ParamRow:
 
     def to_tuple(self, style: Literal["parameters", "attributes", "returns"]):
         name = self.name
+        description = sanitize(self.description, allow_markdown=True)
+
         if style == "parameters":
             default = "_required_" if self.default is None else escape(self.default)
-            return (name, self.annotation, self.description, default)
+            return (name, self.annotation, description, default)
         elif style == "attributes":
-            return (name, self.annotation, self.description)
+            return (name, self.annotation, description)
         elif style == "returns":
-            return (name, self.annotation, self.description)
+            return (name, self.annotation, description)
 
         raise NotImplementedError(f"Unsupported table style: {style}")
 
@@ -595,8 +597,9 @@ class MdRenderer(Renderer):
     @dispatch
     def render(self, el: ds.DocstringParameter) -> ParamRow:
         annotation = self.render_annotation(el.annotation)
-        clean_desc = sanitize(el.description, allow_markdown=True)
-        return ParamRow(el.name, clean_desc, annotation=annotation, default=el.default)
+        return ParamRow(
+            el.name, el.description, annotation=annotation, default=el.default
+        )
 
     # attributes ----
 
@@ -611,7 +614,7 @@ class MdRenderer(Renderer):
     def render(self, el: ds.DocstringAttribute) -> ParamRow:
         return ParamRow(
             el.name,
-            sanitize(el.description or "", allow_markdown=True),
+            el.description or "",
             annotation=self.render_annotation(el.annotation),
         )
 
@@ -680,7 +683,7 @@ class MdRenderer(Renderer):
         # similar to DocstringParameter, but no name or default
         return ParamRow(
             el.name,
-            sanitize(el.description, allow_markdown=True),
+            el.description,
             annotation=self.render_annotation(el.annotation),
         )
 
@@ -689,7 +692,7 @@ class MdRenderer(Renderer):
         # similar to DocstringParameter, but no name or default
         return ParamRow(
             None,
-            sanitize(el.description, allow_markdown=True),
+            el.description,
             annotation=self.render_annotation(el.annotation),
         )
 

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -483,19 +483,19 @@
   List
       # Parameters {.doc-section .doc-section-parameters}
   
-      <code>[**int**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+      <code>[**int**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
       :   A description.
   
       # Returns {.doc-section .doc-section-returns}
   
-      <code>[]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+      <code>[]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
   
       :   A description.
   
       # Attributes {.doc-section .doc-section-attributes}
   
-      <code>[**int**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+      <code>[**int**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
       :   A description.
   '''
@@ -540,19 +540,19 @@
   List
       # Parameters {.doc-section .doc-section-parameters}
   
-      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
       :   A description.
   
       # Returns {.doc-section .doc-section-returns}
   
-      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
   
       :   A description.
   
       # Attributes {.doc-section .doc-section-attributes}
   
-      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+      <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
   
       :   A description.
   '''


### PR DESCRIPTION
This PR fixes a bug in the unreleased description-list param table rendering. When a parameter had no default, it was erroneously rendered as being set to the a default of `None`.