### PR TITLE
fix: descriptions no longer escape quotes inside code

### DIFF
--- a/quartodoc/renderers/base.py
+++ b/quartodoc/renderers/base.py
@@ -13,12 +13,15 @@ def escape(val: str):
     return f"`{val}`"
 
 
-def sanitize(val: str, allow_markdown=False):
+def sanitize(val: str, allow_markdown=False, escape_quotes=False):
     # sanitize common tokens that break tables
     res = val.replace("\n", " ").replace("|", "\\|")
 
     # sanitize elements that get turned into smart quotes
-    res = res.replace("'", r"\'").replace('"', r"\"")
+    # this is to avoid defaults that are strings having their
+    # quotes screwed up.
+    if escape_quotes:
+        res = res.replace("'", r"\'").replace('"', r"\"")
 
     # sanitize elements that can get interpreted as markdown links
     # or citations

--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -60,7 +60,7 @@ class ParamRow:
         name = self.name
         anno = self.annotation
         desc = sanitize(self.description, allow_markdown=True)
-        default = sanitize(str(self.default))
+        default = sanitize(str(self.default), escape_quotes=True)
 
         part_name = (
             Span(Strong(name), Attr(classes=["parameter-name"]))
@@ -219,7 +219,7 @@ class MdRenderer(Renderer):
         el:
             An object representing a type annotation.
         """
-        return sanitize(el)
+        return sanitize(el, escape_quotes=True)
 
     @dispatch
     def render_annotation(self, el: None) -> str:

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -504,60 +504,60 @@
       :   A description.
   '''
 # ---
-# name: test_render_numpydoc_section_return[name: int\n    A description.]
+# name: test_render_numpydoc_section_return[name: int\n    A `"description"`.]
   '''
   Code
       Parameters
       ---
       name: int
-          A description.
+          A `"description"`.
   
       Returns
       ---
       name: int
-          A description.
+          A `"description"`.
   
       Attributes
       ---
       name: int
-          A description.
+          A `"description"`.
   
   Default
       # Parameters {.doc-section .doc-section-parameters}
   
-      | Name   | Type   | Description    | Default    |
-      |--------|--------|----------------|------------|
-      | name   |        | A description. | _required_ |
+      | Name   | Type   | Description        | Default    |
+      |--------|--------|--------------------|------------|
+      | name   |        | A `"description"`. | _required_ |
   
       # Returns {.doc-section .doc-section-returns}
   
-      | Name   | Type   | Description    |
-      |--------|--------|----------------|
-      | name   | int    | A description. |
+      | Name   | Type   | Description        |
+      |--------|--------|--------------------|
+      | name   | int    | A `"description"`. |
   
       # Attributes {.doc-section .doc-section-attributes}
   
-      | Name   | Type   | Description    |
-      |--------|--------|----------------|
-      | name   | int    | A description. |
+      | Name   | Type   | Description        |
+      |--------|--------|--------------------|
+      | name   | int    | A `"description"`. |
   
   List
       # Parameters {.doc-section .doc-section-parameters}
   
       <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} []{.parameter-annotation}</code>
   
-      :   A description.
+      :   A `"description"`.
   
       # Returns {.doc-section .doc-section-returns}
   
       <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
   
-      :   A description.
+      :   A `"description"`.
   
       # Attributes {.doc-section .doc-section-attributes}
   
       <code>[**name**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
   
-      :   A description.
+      :   A `"description"`.
   '''
 # ---

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -223,7 +223,7 @@ def test_render_doc_signature_name_alias_of_alias(snapshot, renderer):
 @pytest.mark.parametrize(
     "doc",
     [
-        """name: int\n    A description.""",
+        """name: int\n    A `"description"`.""",
         """int\n    A description.""",
     ],
 )


### PR DESCRIPTION
This PR addresses 

* https://github.com/posit-dev/great-tables/issues/476

By not escaping quotes inside descriptions.