### PR TITLE
docs: fix sidebar preview and collapse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ docs-build-readme:
 docs-build: export PLUM_SIMPLE_DOC=1
 docs-build: docs-build-examples
 	cd docs && quarto add --no-prompt ..
-	cd docs && quartodoc build
+	cd docs && quartodoc build --verbose
 	cd docs && quartodoc interlinks
 	quarto render docs
 

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ docs-build-readme:
 
 docs-build: export PLUM_SIMPLE_DOC=1
 docs-build: docs-build-examples
-	cd docs && quarto add --no-prompt ..
 	cd docs && quartodoc build --verbose
 	cd docs && quartodoc interlinks
+	cd docs && quarto add --no-prompt ..
 	quarto render docs
 
 test-interlinks: quartodoc/tests/example_interlinks/test.md

--- a/docs/get-started/sidebar.qmd
+++ b/docs/get-started/sidebar.qmd
@@ -23,12 +23,16 @@ with a [Quarto sidebar configuration](https://quarto.org/docs/websites/website-n
 The Quarto [`metadata-files` option](https://quarto.org/docs/projects/quarto-projects.html#metadata-includes) ensures
 it's included with the configuration in `_quarto.yml`.
 
+::: { .callout-note}
 Here is what the sidebar for the [quartodoc reference page](/api) looks like:
 
-<div class="sourceCode">
-<pre class="sourceCode yaml"><code class="sourceCode yaml">{{< include /api/_sidebar.yml >}}
-</code></pre>
-</div>
+<details>
+```yaml
+{{< include /api/_sidebar.yml >}}
+```
+</details>
+
+:::
 
 ## Customizing the sidebar
 


### PR DESCRIPTION
This PR fixes the preview of the sidebar yaml on the sidebar guide page (previously the raw include directive appeared)