### PR TITLE
Fix: add trailing commas to multiline signature

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -268,7 +268,7 @@ class MdRenderer(Renderer):
 
         flat_sig = f"{name}({', '.join(pars)})"
         if len(flat_sig) > 80:
-            indented = [" " * 4 + par for par in pars]
+            indented = [" " * 4 + par + "," for par in pars]
             sig = "\n".join([f"{name}(", *indented, ")"])
         else:
             sig = flat_sig

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -5,9 +5,9 @@
   
   ```python
   tests.example_signature.a_complex_signature(
-      x: list[C | int | None]
-      y: pathlib.Pathlib
-      z
+      x: list[C | int | None],
+      y: pathlib.Pathlib,
+      z,
   )
   ```
   
@@ -26,9 +26,9 @@
   
   ```python
   tests.example_signature.a_complex_signature(
-      x: list[C | int | None]
-      y: pathlib.Pathlib
-      z
+      x: list[C | int | None],
+      y: pathlib.Pathlib,
+      z,
   )
   ```
   


### PR DESCRIPTION
This PR fixes the signature, to include trailing commas after parameters. Here's an example of a fixed signature from our docs:

<img width="795" alt="image" src="https://github.com/user-attachments/assets/3dcc4792-7641-4661-943c-b2689343520f">
