### PR TITLE
Prioritizing source directory in the sys.path

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -592,8 +592,8 @@ class Builder:
 
         if self.source_dir:
             import sys
-
-            sys.path.append(self.source_dir)
+            if self.source_dir != sys.path[0]:
+                sys.path.insert(0, self.source_dir)
 
         # shaping and collection ----
 


### PR DESCRIPTION
This PR prioritizes the supplied source directory in the `sys.path`. 

Currently, the source directory of the `Builder` instance, when supplied, is appended to `sys.path`:  


```python
def build(self, filter: str = "*"):
    ...
    if self.source_dir:
	import sys
        sys.path.append(self.source_dir)
```        
     
I think the source directory should come first:

```python
def build(self, filter: str = "*"):
    ...
    if self.source_dir:
	import sys
        if sys.path[0] != self.source_dir:
            sys.path.insert(0, self.source_dir)
```

By inserting itself into the first position in the path, module imports from the given source directory are prioritized over other modules. In particular, if one has a source file that happens to share the same name with another file also in the path (e.g. `random`, `trace`, `collections`, etc.), this change ensures quartodoc/griffe picks the package-level module over a base module. 

For me, this fixes griffe-related resolution issues that arise from mixing relative imports with editable installs (#323).