### PR TITLE
docs: regenerate gh readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
           fi
         env:
           REQUIREMENTS: ${{ matrix.requirements }}
-      - name: Test building starter template
-        run: |
-          make test-overview-template
       - name: Run tests
         run: |
           pytest --cov
@@ -101,6 +98,9 @@ jobs:
           python -m pip install shiny shinylive
           python -m pip install --no-deps dascore==0.0.8
       - uses: quarto-dev/quarto-actions/setup@v2
+      - name: Test building starter template
+        run: |
+          make test-overview-template
       - name: Build docs
         run: |
           make docs-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           fi
         env:
           REQUIREMENTS: ${{ matrix.requirements }}
+      - name: Test building starter template
+        run: |
+          make test-overview-template
       - name: Run tests
         run: |
           pytest --cov

--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,7 @@ docs-build: docs-build-examples
 	cd docs && quarto add --no-prompt ..
 	quarto render docs
 
+test-overview-template:
+	python scripts/build_tmp_starter.py
+
 test-interlinks: quartodoc/tests/example_interlinks/test.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Overview
 
+
 [![CI](https://github.com/machow/quartodoc/actions/workflows/ci.yml/badge.svg)](https://github.com/machow/quartodoc/actions/workflows/ci.yml)
 
 **quartodoc** lets you quickly generate Python package API reference
@@ -30,15 +31,13 @@ or from GitHub
 python -m pip install git+https://github.com/machow/quartodoc.git
 ```
 
-<div>
-
-> **Install Quarto**
+> [!IMPORTANT]
+>
+> ### Install Quarto
 >
 > If you haven’t already, you’ll need to [install
 > Quarto](https://quarto.org/docs/get-started/) before you can use
 > quartodoc.
-
-</div>
 
 ## Basic use
 
@@ -60,15 +59,20 @@ project:
 
 # tell quarto to read the generated sidebar
 metadata-files:
-  - _sidebar.yml
+  - api/_sidebar.yml
 
+# tell quarto to read the generated styles
+format:
+  css:
+    - api/_styles-quartodoc.css
 
 quartodoc:
   # the name used to import the package you want to create reference docs for
   package: quartodoc
 
-  # write sidebar data to this file
-  sidebar: _sidebar.yml
+  # write sidebar and style data
+  sidebar: api/_sidebar.yml
+  css: api/_styles-quartodoc.css
 
   sections:
     - title: Some functions

--- a/README.md
+++ b/README.md
@@ -59,20 +59,20 @@ project:
 
 # tell quarto to read the generated sidebar
 metadata-files:
-  - api/_sidebar.yml
+  - reference/_sidebar.yml
 
 # tell quarto to read the generated styles
 format:
   css:
-    - api/_styles-quartodoc.css
+    - reference/_styles-quartodoc.css
 
 quartodoc:
   # the name used to import the package you want to create reference docs for
   package: quartodoc
 
   # write sidebar and style data
-  sidebar: api/_sidebar.yml
-  css: api/_styles-quartodoc.css
+  sidebar: reference/_sidebar.yml
+  css: reference/_styles-quartodoc.css
 
   sections:
     - title: Some functions

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Check out the below screencast for a walkthrough of creating a
 documentation site, or read on for instructions.
 
 <p align="center">
+
 <a href="https://www.loom.com/share/fb4eb736848e470b8409ba46b514e2ed">
 <img src="https://cdn.loom.com/sessions/thumbnails/fb4eb736848e470b8409ba46b514e2ed-00001.gif" width="75%">
 </a>
@@ -53,6 +54,8 @@ you need to add a `quartodoc` section to the top level your
 `_quarto.yml` file. Below is a minimal example of a configuration that
 documents the `quartodoc` package:
 
+<!-- Starter Template -->
+
 ``` yaml
 project:
   type: website
@@ -63,8 +66,9 @@ metadata-files:
 
 # tell quarto to read the generated styles
 format:
-  css:
-    - reference/_styles-quartodoc.css
+  html:
+    css:
+      - reference/_styles-quartodoc.css
 
 quartodoc:
   # the name used to import the package you want to create reference docs for

--- a/docs/get-started/overview.qmd
+++ b/docs/get-started/overview.qmd
@@ -71,6 +71,8 @@ Getting started with quartodoc takes two steps: configuring quartodoc, then gene
 
 You can configure quartodoc alongside the rest of your Quarto site in the [`_quarto.yml`](https://quarto.org/docs/projects/quarto-projects.html) file you are already using for Quarto.  To [configure quartodoc](./basic-docs.qmd#site-configuration), you need to add a `quartodoc` section to the top level your `_quarto.yml` file.  Below is a minimal example of a configuration that documents the `quartodoc` package:
 
+<!-- Starter Template -->
+
 ```yaml
 project:
   type: website
@@ -81,8 +83,9 @@ metadata-files:
 
 # tell quarto to read the generated styles
 format:
-  css:
-    - reference/_styles-quartodoc.css
+  html:
+    css:
+      - reference/_styles-quartodoc.css
 
 quartodoc:
   # the name used to import the package you want to create reference docs for

--- a/docs/get-started/overview.qmd
+++ b/docs/get-started/overview.qmd
@@ -77,20 +77,20 @@ project:
 
 # tell quarto to read the generated sidebar
 metadata-files:
-  - api/_sidebar.yml
+  - reference/_sidebar.yml
 
 # tell quarto to read the generated styles
 format:
   css:
-    - api/_styles-quartodoc.css
+    - reference/_styles-quartodoc.css
 
 quartodoc:
   # the name used to import the package you want to create reference docs for
   package: quartodoc
 
   # write sidebar and style data
-  sidebar: api/_sidebar.yml
-  css: api/_styles-quartodoc.css
+  sidebar: reference/_sidebar.yml
+  css: reference/_styles-quartodoc.css
 
   sections:
     - title: Some functions

--- a/scripts/build_tmp_starter.py
+++ b/scripts/build_tmp_starter.py
@@ -1,0 +1,32 @@
+import re
+import tempfile
+import subprocess
+from pathlib import Path
+from quartodoc.__main__ import build
+
+p = Path("docs/get-started/overview.qmd")
+overview = p.read_text()
+
+indx = overview.index("<!-- Starter Template -->")
+yml_blurb = overview[indx:]
+
+match = re.search(r"```yaml\s*(.*?)```", yml_blurb, re.DOTALL)
+if match is None:
+    raise Exception()
+
+template = match.group(1)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    tmpdir = Path(tmpdir)
+    # Write the template to a file
+    p_quarto = tmpdir / "_quarto.yml"
+    p_quarto.write_text(template)
+
+    try:
+        build(["--config", str(p_quarto), "--filter", "quartodoc"])
+    except SystemExit as e:
+        if e.code != 0:
+            raise Exception() from e
+    subprocess.run(["quarto", "render", str(p_quarto.parent)])
+
+    print("SITE RENDERED SUCCESSFULLY")


### PR DESCRIPTION
This PR addresses an issue flagged by @chendaniely -- the intro snippet produces errors.

Note that one important piece here is that the github readme is generated from the quartodoc homepage (currently https://machow.github.io/quartodoc/get-started/overview.html). But this hadn't been regenerated to reflect the latest there.

I don't love how verbose the intro snippet is now, but let's just get it working in this PR. I think there are some nice ways to streamline things down the road!

TODO: add a test of the intro snippet