### PR TITLE
Remove self from class initializer signature

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -190,7 +190,7 @@ class MdRenderer(Renderer):
 
     def _fetch_method_parameters(self, el: dc.Function):
         # adapted from mkdocstrings-python jinja tempalate
-        if el.parent and el.parent.is_class and len(el.parameters) > 0:
+        if (el.is_class or (el.parent and el.parent.is_class)) and len(el.parameters) > 0:
             if el.parameters[0].name in {"self", "cls"}:
                 return dc.Parameters(*list(el.parameters)[1:])
 

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -46,7 +46,7 @@
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
   
   ```python
-  tests.example_class.C(self, x, y)
+  tests.example_class.C(x, y)
   ```
   
   The short summary.
@@ -112,7 +112,7 @@
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
   
   ```python
-  tests.example_class.C(self, x, y)
+  tests.example_class.C(x, y)
   ```
   
   The short summary.
@@ -178,7 +178,7 @@
   # quartodoc.tests.example_class.AttributesTable { #quartodoc.tests.example_class.AttributesTable }
   
   ```python
-  tests.example_class.AttributesTable(self)
+  tests.example_class.AttributesTable()
   ```
   
   The short summary.


### PR DESCRIPTION
In #271 , it appears the intention was to remove self method signatures, however, it seems that self continued to appear in class initializer signatures. It looks like this is because the condition `el.parent and el.parent.is_class` applies to class methods, but not classes themselves.