### PR TITLE
feat: interlinks autolink

### DIFF
--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -181,11 +181,11 @@ local function prepend_aliases(aliases)
                 if string.sub(item.name, 1, string.len(full) + 1) == (full .. ".") then
                     -- replace full .. "." with alias .. "."
                     local prefix
-                    if not alias or alias == "" then
+                    if not alias or pandoc.utils.stringify(alias) == "" then
                         prefix = ""
                     else
                         -- TODO: ensure alias doesn't end with period
-                        prefix = alias .. "."
+                        prefix = pandoc.utils.stringify(alias) .. "."
                     end
                     local new_name = prefix .. string.sub(item.name, string.len(full) + 2)
                     table.insert(new_inv.items, copy_replace(item, "name", new_name))

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -311,10 +311,11 @@ function Code(code)
 
     -- detect and remove shortening syntax (~~ prefix)
     local is_shortened = code.text:sub(1, 2) == "~~"
-    if code.text:match("%(%s*%)") then
-        text = code.text:gsub("^~~", ""):gsub("%(%s*%)", "")
+    local unprefixed = code.text:gsub("^~~", "")
+    if unprefixed:match("%(%s*%)") then
+        text = unprefixed:gsub("%(%s*%)", "")
     else
-        text = code.text
+        text = unprefixed
     end
 
 
@@ -325,17 +326,18 @@ function Code(code)
     -- determine replacement, used if no link text specified ----
     if item == nil then
         quarto.log.warning(code)
+        code.text = unprefixed
         return code
     end
 
     -- shorten text if shortening syntax used
     if is_shortened then
         -- keep text after last period (.)
-        local split = mysplit(code.text:gsub("^~~", ""), ".")
+        local split = mysplit(unprefixed, ".")
         if #split > 0 then
             code.text = split[#split]
         else
-            code.text = code.text:sub(1, 2)
+            code.text = unprefixed
         end
     end
 

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -11,16 +11,16 @@ local function read_inv_text(filename)
     local project = str:match("# Project: (%S+)")
     local version = str:match("# Version: (%S+)")
 
-    local data = {project = project, version = version, items = {}}
+    local data = { project = project, version = version, items = {} }
 
     local ptn_data =
         "^" ..
-        "(.-)%s+" ..        -- name
-        "([%S:]-):" ..      -- domain
-        "([%S]+)%s+" ..     -- role
-        "(%-?%d+)%s+" ..     -- priority
-        "(%S*)%s+" ..       -- uri
-        "(.-)\r?$"         -- dispname
+        "(.-)%s+" ..     -- name
+        "([%S:]-):" ..   -- domain
+        "([%S]+)%s+" ..  -- role
+        "(%-?%d+)%s+" .. -- priority
+        "(%S*)%s+" ..    -- uri
+        "(.-)\r?$"       -- dispname
 
 
     -- Iterate through each line in the file content
@@ -48,7 +48,6 @@ local function read_inv_text(filename)
 end
 
 local function read_json(filename)
-
     local file = io.open(filename, "r")
     if file == nil then
         return nil
@@ -66,7 +65,6 @@ local function read_inv_text_or_json(base_name)
         -- TODO: refactors so we don't just close the file immediately
         io.close(file)
         json = read_inv_text(base_name .. ".txt")
-
     else
         json = read_json(base_name .. ".json")
     end
@@ -77,7 +75,6 @@ end
 local inventory = {}
 
 local function lookup(search_object)
-
     local results = {}
     for _, inv in ipairs(inventory) do
         for _, item in ipairs(inv.items) do
@@ -98,7 +95,7 @@ local function lookup(search_object)
                 goto continue
             else
                 if search_object.domain or item.domain == "py" then
-                  table.insert(results, item)
+                    table.insert(results, item)
                 end
 
                 goto continue
@@ -122,13 +119,13 @@ local function lookup(search_object)
     return nil
 end
 
-local function mysplit (inputstr, sep)
+local function mysplit(inputstr, sep)
     if sep == nil then
-            sep = "%s"
+        sep = "%s"
     end
-    local t={}
-    for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-            table.insert(t, str)
+    local t = {}
+    for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
+        table.insert(t, str)
     end
     return t
 end

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -1,3 +1,7 @@
+local inventory = {} -- sphinx inventories
+local autolink       -- set in Meta
+local autolink_ignore_token = "qd-no-link"
+
 local function read_inv_text(filename)
     -- read file
     local file = io.open(filename, "r")
@@ -73,8 +77,6 @@ local function read_inv_text_or_json(base_name)
 end
 
 -- each inventory has entries: project, version, items
-local inventory = {}
-
 local function lookup(search_object)
     local results = {}
     for _, inv in ipairs(inventory) do
@@ -149,6 +151,16 @@ local function copy_replace(original, key, new_value)
     copy[key] = new_value
 
     return copy
+end
+
+local function contains(list, value)
+    -- check if list contains a value
+    for i, v in ipairs(list) do
+        if v == value then
+            return true
+        end
+    end
+    return false
 end
 
 local function prepend_aliases(aliases)
@@ -265,7 +277,7 @@ function Link(link)
 end
 
 function Code(code)
-    if not autolink then
+    if (not autolink) or contains(code.classes, autolink_ignore_token) then
         return code
     end
 
@@ -314,6 +326,7 @@ return {
                 autolink = false
             end
 
+            local aliases
             if meta.interlinks and meta.interlinks.aliases then
                 aliases = meta.interlinks.aliases
             else

--- a/_extensions/interlinks/interlinks.lua
+++ b/_extensions/interlinks/interlinks.lua
@@ -311,7 +311,8 @@ function Code(code)
 
     -- detect and remove shortening syntax (~~ prefix)
     local is_shortened = code.text:sub(1, 2) == "~~"
-    local unprefixed = code.text:gsub("^~~", "")
+    local is_short_dot = code.text:sub(1, 3) == "~~."
+    local unprefixed = code.text:gsub("^~~%.?", "")
     if unprefixed:match("%(%s*%)") then
         text = unprefixed:gsub("%(%s*%)", "")
     else
@@ -335,11 +336,17 @@ function Code(code)
         -- keep text after last period (.)
         local split = mysplit(unprefixed, ".")
         if #split > 0 then
-            code.text = split[#split]
+            local new_name = split[#split]
+            if is_short_dot then
+                -- if shortened with dot, keep the dot
+                new_name = "." .. new_name
+            end
+            code.text = new_name
         else
             code.text = unprefixed
         end
     end
+
 
     return pandoc.Link(code, item.uri:gsub("%$$", search.name))
 end

--- a/_extensions/interlinks/objects.txt
+++ b/_extensions/interlinks/objects.txt
@@ -1,0 +1,6 @@
+# Sphinx inventory version 2
+# Project: quartodoc
+# Version: 0.0.9999
+# The remainder of this file is compressed using zlib.
+some_func py:function 1 api/some_func.html -
+a.b.c py:function 1 api/a.b.c.html -

--- a/_extensions/interlinks/objects.txt
+++ b/_extensions/interlinks/objects.txt
@@ -4,3 +4,4 @@
 # The remainder of this file is compressed using zlib.
 some_func py:function 1 api/some_func.html -
 a.b.c py:function 1 api/a.b.c.html -
+quartodoc.Auto py:class 1 api/Auto.html -

--- a/_extensions/interlinks/test.qmd
+++ b/_extensions/interlinks/test.qmd
@@ -1,0 +1,14 @@
+---
+filters:
+  - interlinks.lua
+interlinks:
+  autolink: true
+  #sources:
+  #  test:
+  #    url: https://example.com
+---
+
+* `some_func`
+* `some_func + some_func`
+* `a.b.c`
+* `~a.b.c`

--- a/_extensions/interlinks/test.qmd
+++ b/_extensions/interlinks/test.qmd
@@ -3,12 +3,19 @@ filters:
   - interlinks.lua
 interlinks:
   autolink: true
+  aliases:
+    quartodoc: null
   #sources:
   #  test:
   #    url: https://example.com
 ---
 
 * `some_func`
+* `some_func()`
+* `some_func(a=1)`
 * `some_func + some_func`
 * `a.b.c`
 * `~a.b.c`
+* `a.b.c()`
+* `quartodoc.Auto()`
+* `Auto()`

--- a/_extensions/interlinks/test.qmd
+++ b/_extensions/interlinks/test.qmd
@@ -13,6 +13,7 @@ interlinks:
 * `some_func`
 * `some_func()`
 * `some_func(a=1)`
+* `some_func()`{.qd-no-link}
 * `some_func + some_func`
 * `a.b.c`
 * `~a.b.c`

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -16,6 +16,9 @@ filters:
 
 interlinks:
   fast: true
+  autolink: true
+  aliases:
+    quartodoc: [null, qd]
   sources:
     python:
       url: https://docs.python.org/3/

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -56,9 +56,13 @@ website:
             - get-started/basic-content.qmd
             - get-started/basic-building.qmd
             - get-started/crossrefs.qmd
-            - get-started/interlinks.qmd
             - get-started/sidebar.qmd
             - get-started/extending.qmd
+
+        - section: Interlinking
+          contents:
+            - get-started/interlinks.qmd
+            - get-started/interlinks-autolink.qmd
 
         - section: "Docstrings"
           contents:

--- a/docs/get-started/crossrefs.qmd
+++ b/docs/get-started/crossrefs.qmd
@@ -7,6 +7,26 @@ jupyter:
     name: python3
 ---
 
+This page describes the different ways that quartodoc can link to other pages,
+where each style of link is used, and how to set them up.
+
+Here are the key details covered on this page:
+
+* Link to a page (.qmd file) using the path to the file.
+* Link to a function name by using the [interlinks filter's](./interlinks.qmd) special syntaxes.
+* Link type annotations in documented functions by enabling the [interlinks filter](./interlinks.qmd).
+
+:::{.callout-tip title="Guide pages on each linking style"}
+
+Here are some examples of different linking styles and their corresponding guide pages.
+
+| Link syntax | Example | Guide page |
+| --- | --- | --- |
+| Qmd path  | ``[get_object](/reference/get_object.qmd)`` | [Quarto - markdown basics](https://quarto.org/docs/authoring/markdown-basics.html#links-images) |
+| Interlink (full) | ``[](`quartodoc.get_object`)`` | [Interlinks filter](./interlinks.qmd) |
+| Interlink (autolink) | `` `quartodoc.get_object` `` | [Interlinks filter - autolink mode](./interlinks-autolink.qmd) |
+:::
+
 ## Linking by path
 
 You can use [quarto's markdown linking syntax](https://quarto.org/docs/authoring/markdown-basics.html#links-images)
@@ -48,5 +68,9 @@ on turning type annotations into links.
 
 ## Type annotations in docstrings
 
-This is planned, but currently unimplemented. See [this issue](https://github.com/machow/quartodoc/issues/22)
-on turning type annotations into links.
+Creating links from type annotations for a function and their reference pages is supported via the interlinks filter. See the [Rendering Interlinks in API Docs](./interlinks.qmd#rendering-interlinks-in-api-docs) section on the interlinks page for more.
+
+Essentially, interlinking type annotations requires:
+
+* Setting the quartodoc `render_interlinks` config option to `true`.
+* Enabling the [interlinks filter](./interlinks.qmd).

--- a/docs/get-started/interlinks-autolink.qmd
+++ b/docs/get-started/interlinks-autolink.qmd
@@ -33,10 +33,6 @@ Note that in addition to enabling autolink mode, the `_quarto.yml` above uses `a
 | short dot (`~~.`) | `` `~~.quartodoc.get_object()` `` | `~~.quartodoc.get_object()` |
 | unmatched link | `` `~~unmatched_func()` `` | `unmatched_func()` |
 
-
-
-
-
 ## What gets autolinked?
 
 Any inline code that resembles a item name in [interlink syntax](./interlinks.qmd#link-formats) will be autolinked.

--- a/docs/get-started/interlinks-autolink.qmd
+++ b/docs/get-started/interlinks-autolink.qmd
@@ -30,7 +30,12 @@ Note that in addition to enabling autolink mode, the `_quarto.yml` above uses `a
 | alias (qd) | `` `qd.get_object()` `` | `qd.get_object()` | 
 | alias (null) | `` `get_object()` `` | `get_object()` |
 | shortening (`~~`) | `` `~~quartodoc.get_object()` `` | `~~quartodoc.get_object()` |
+| short dot (`~~.`) | `` `~~.quartodoc.get_object()` `` | `~~.quartodoc.get_object()` |
 | unmatched link | `` `~~unmatched_func()` `` | `unmatched_func()` |
+
+
+
+
 
 ## What gets autolinked?
 

--- a/docs/get-started/interlinks-autolink.qmd
+++ b/docs/get-started/interlinks-autolink.qmd
@@ -17,12 +17,19 @@ interlinks:
   # enable autolink mode
   autolink: true
   # aliases allow you to refer to functions
-  # without their module name.
+  # without their module name, or using a shortened name
   aliases:
-    quartodoc: null
+    quartodoc: [null, qd]
 ```
 
 Note that in addition to enabling autolink mode, the `_quarto.yml` above uses `aliases:` to allow you to refer to `quartodoc` functions, without needing the module name. For example, using `get_object` instead of `quartodoc.get_object`.
+
+| link style | link syntax | result |
+| --- | --- | --- |
+| full path | `` `quartodoc.get_object()` `` | `quartodoc.get_object()` |
+| alias (qd) | `` `qd.get_object()` `` | `qd.get_object()` | 
+| alias (null) | `` `get_object()` `` | `get_object()` |
+| shortening (`~~`) | `` `~~quartodoc.get_object()` `` | `~~quartodoc.get_object()` |
 
 ## What gets autolinked?
 

--- a/docs/get-started/interlinks-autolink.qmd
+++ b/docs/get-started/interlinks-autolink.qmd
@@ -1,0 +1,69 @@
+---
+title: Interlinks filter - autolink mode
+---
+
+Autolink mode enables you to convert inline code, like `` `get_object()` ``, into a link to the function's reference page. It is an interlinks filter setting, enabled by setting `autolink: true`.
+
+## Basic use
+
+Here is a basic example of enabling autolink mode in your `_quarto.yml` file:
+
+```yaml
+filters:
+  # requires running quarto add machow/quartodoc
+  - interlinks
+
+interlinks:
+  # enable autolink mode
+  autolink: true
+  # aliases allow you to refer to functions
+  # without their module name.
+  aliases:
+    quartodoc: null
+```
+
+Note that in addition to enabling autolink mode, the `_quarto.yml` above uses `aliases:` to allow you to refer to `quartodoc` functions, without needing the module name. For example, using `get_object` instead of `quartodoc.get_object`.
+
+## What gets autolinked?
+
+Any inline code that resembles a item name in [interlink syntax](./interlinks.qmd#link-formats) will be autolinked.
+In addition, autolink mode supports names with parentheses at the end.
+Below are some examples.
+
+Linked:
+
+* `` `a.b.c` ``
+* `` `a.b.c()` ``
+
+Not linked:
+
+* `` `a.b.c(x=1)` ``
+* `` `a.b.c + a.b.c` ``
+* `` `-a.b.c` ``
+
+## Disable autolink on item
+
+Use the `qd-no-link` class to disable autolinking on a single piece of code. For example, `` `some_func()`{.qd-no-link} ``.
+
+## Disable autolink on page
+
+Set autolink to false in the YAML top-matter for a page, in order to disable autolinking on that page.
+
+```
+---
+interlinks:
+    autolink: false
+---
+
+Autolink won't apply here: `some_func()`
+
+or here: `another_func()`
+```
+
+This works because quarto uses the YAML top-matter to override your `_quarto.yml` settings.
+Technically, it merges your `_quarto.yml` and top-matter settings together, by doing the following:
+
+* Take `_quarto.yml` settings.
+* Override with any new top-matter settings.
+  - dictionary items replace each other (e.g. `autolink: false` replaces old setting).
+  - list items are appended.

--- a/docs/get-started/interlinks-autolink.qmd
+++ b/docs/get-started/interlinks-autolink.qmd
@@ -30,6 +30,7 @@ Note that in addition to enabling autolink mode, the `_quarto.yml` above uses `a
 | alias (qd) | `` `qd.get_object()` `` | `qd.get_object()` | 
 | alias (null) | `` `get_object()` `` | `get_object()` |
 | shortening (`~~`) | `` `~~quartodoc.get_object()` `` | `~~quartodoc.get_object()` |
+| unmatched link | `` `~~unmatched_func()` `` | `unmatched_func()` |
 
 ## What gets autolinked?
 

--- a/docs/get-started/interlinks.qmd
+++ b/docs/get-started/interlinks.qmd
@@ -127,6 +127,22 @@ quarto preview
 | rst | shortened | `` :ref:`~quartodoc.get_object` `` | :ref:`~quartodoc.get_object` |
 -->
 
+## Link aliases
+
+Use `interlinks.aliases` in `_quarto.yml` to refer to functions without their module name (or using a shortened version of it).
+
+For example the following config sets aliases for `quartodoc` and `pandas`:
+
+```yaml
+interlinks:
+  aliases:
+    quartodoc: null
+    pandas: pd
+```
+
+In this case, you can refer to `quartodoc.get_object` as `get_object`, and `pandas.DataFrame` as `pd.DataFrame`.
+
+
 ## Link filtering syntax
 
 Sometimes multiple documentation sites use the same target (e.g. function) names.


### PR DESCRIPTION
This WIP PR automatically formats code as interlinks. Addresses #328 

Essentially:

* interlinks now supports a `interlinks.autolinks = True` setting, that turns inline Code directly to links.
* This means you don't need to use ``[](`some_function`)`` syntax.
* Currently...
  - No link shortening with `~`. I don't think it would be confusing for this approach.
  - `~a.b.c` when interlinks still uses `~a.b.c` for the link text (use full link syntax for name shortening)
  - `~a.b.c` when unmatched returns the original code `~a.b.c`
* Aliases
  - set `interlinks.aliases` to allow linking functions like `quartodoc.Auto` by just writing `Auto`
* Opting out
  - use the `.qd-no-link` class to tell quartodoc not to try interlinking. E.g. `` `my_func`{.qd-no-link} ``

**Alias example**

```
interlinks:
  aliases:
    shiny: null          # refer to functions w/o writing shiny.
    quartodoc: qd   # use qd as alias. E.g. qd.Auto
```

**thinking about**

Basically we need to ensure:

1. When a page author feels that a submodule's functions don't need their full import path, autolinks still work (e.g. via some alias mechanism etc..).
2. When a page author feels like above, but using some module alias (e.g. pd.DataFrame), autolinks still work.
3. The package being documented can also work like above (could be through same mechanism, or another).


**edit:**

Now possible to define multiple aliases, using

```yaml
interlinks:
  aliases:
    quartodoc: [null, qd]
```

Also shortening syntax enabled, using `~~` as a prefix.