### PR TITLE
Fix!: reference title now is in yaml topmatter

### DIFF
--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -20,8 +20,7 @@ from .parsers import get_parser_defaults
 from .renderers import Renderer
 from .validation import fmt_all
 from ._pydantic_compat import ValidationError
-from .pandoc.blocks import Blocks, Header
-from .pandoc.components import Attr
+from .pandoc.blocks import Blocks, Meta
 
 
 from typing import Any
@@ -450,7 +449,8 @@ class Builder:
     dir:
         Name of API directory.
     title:
-        Title of the API index page.
+        Title of the API index page. This is sets the title in the yaml topmatter.
+        Set title to None to not produce any topmatter at all.
     renderer: Renderer
         The renderer used to convert docstrings (e.g. to markdown).
     options:
@@ -646,9 +646,12 @@ class Builder:
         content = self.renderer.summarize(blueprint)
         _log.info(f"Writing index to directory: {self.dir}")
 
-        final = str(
-            Blocks([Header(1, self.title, Attr(classes=["doc", "doc-index"])), content])
-        )
+        if self.title is not None:
+            meta = [Meta({"title": self.title})]
+        else:
+            meta = []
+
+        final = str(Blocks([*meta, content]))
 
         p_index = Path(self.dir) / self.out_index
         p_index.parent.mkdir(exist_ok=True, parents=True)

--- a/quartodoc/autosummary.py
+++ b/quartodoc/autosummary.py
@@ -789,7 +789,7 @@ class Builder:
     # constructors ----
 
     @classmethod
-    def from_quarto_config(cls, quarto_cfg: "str | dict"):
+    def from_quarto_config(cls, quarto_cfg: "str | dict") -> Builder:
         """Construct a Builder from a configuration object (or yaml file)."""
 
         # TODO: validation / config model loading

--- a/quartodoc/pandoc/blocks.py
+++ b/quartodoc/pandoc/blocks.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 
 import collections.abc as abc
 import itertools
-import sys
+import yaml
 
 from textwrap import indent
 from dataclasses import dataclass
-from typing import Literal, Optional, Sequence, Union
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    TypeAlias = "TypeAlias"
+from typing import Literal, Optional, Sequence, Union, Any
+from typing_extensions import TypeAlias
 
 from quartodoc.pandoc.components import Attr
 from quartodoc.pandoc.inlines import (
@@ -200,6 +196,23 @@ class Para(Block):
     def as_list_item(self):
         content = inlinecontent_to_str(self.content)
         return f"{content}\n\n"
+
+
+@dataclass
+class Meta(Block):
+    """
+    A metadata block
+    """
+
+    metadata: dict[str, Any]
+
+    def __str__(self):
+        """
+        Return metadata as markdown
+        """
+
+        str_yaml = yaml.safe_dump(self.metadata)
+        return f"---\n{str_yaml}\n---"
 
 
 @dataclass

--- a/quartodoc/pandoc/blocks.py
+++ b/quartodoc/pandoc/blocks.py
@@ -211,7 +211,7 @@ class Meta(Block):
         Return metadata as markdown
         """
 
-        str_yaml = yaml.safe_dump(self.metadata)
+        str_yaml = yaml.safe_dump(self.metadata, sort_keys=False)
         return f"---\n{str_yaml}\n---"
 
 

--- a/quartodoc/tests/pandoc/test_blocks.py
+++ b/quartodoc/tests/pandoc/test_blocks.py
@@ -9,6 +9,7 @@ from quartodoc.pandoc.blocks import (
     DefinitionList,
     Div,
     Header,
+    Meta,
     OrderedList,
     Para,
     Plain,
@@ -337,6 +338,11 @@ def test_header():
 
     h = Header(2, "A", Attr("header-id", classes=["c1", "c2"]))
     assert str(h) == "## A {#header-id .c1 .c2}"
+
+
+def test_meta():
+    m = Meta({"title": "AAA", "author": "BBB"})
+    assert str(m) == """---\ntitle: AAA\nauthor: BBB\n\n---"""
 
 
 def test_orderedlist():

--- a/quartodoc/tests/test_builder.py
+++ b/quartodoc/tests/test_builder.py
@@ -128,3 +128,24 @@ def test_builder_generate_sidebar_options(tmp_path, snapshot):
     assert qd_sidebar["search"]
 
     assert yaml.dump(d_sidebar) == snapshot
+
+
+def test_builder_no_title_no_topmatter(tmp_path):
+    cfg = yaml.safe_load(
+        """
+    quartodoc:
+      package: quartodoc.tests.example
+      title: null
+      sections:
+        - title: first section
+          contents: [a_func]
+    """
+    )
+
+    builder = Builder.from_quarto_config(cfg)
+    builder.dir = str(tmp_path)
+    bp = blueprint(builder.layout)
+    builder.write_index(bp)
+
+    index = (Path(tmp_path) / "index.qmd").read_text()
+    assert not index.startswith("---")


### PR DESCRIPTION
Addresses #399 by putting title in yaml topmatter for the API Reference index.

Note that if title is set to null, then no topmatter is generated. This ensures that people can extend the index page. For example, by setting `out_index: _index.qmd` and then generating an `index.qmd` like this:

```
---
title: a custom manual title
bbb: some other topmatter
---

Some custom content


{{< include /reference/_index.qmd >}}

Some more content
```