### PR TITLE
Feat dl tables

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -495,7 +495,7 @@ class MdRenderer(Renderer):
                 # and not isinstance(el, layout.DocClass)
             ):
                 # Collect SummaryRow objects and render as TOC
-                attr_rows = [self.summarize_toc(attr) for attr in raw_attrs]
+                attr_rows = [self.summarize(attr) for attr in raw_attrs]
                 _attrs_table = self._render_summary_table(attr_rows, self.table_style_tocs, include_headers=True)
                 attrs = f"{sub_header} Attributes\n\n{_attrs_table}"
                 attr_docs.append(attrs)
@@ -503,7 +503,7 @@ class MdRenderer(Renderer):
             # classes summary table ----
             if raw_classes:
                 # Collect SummaryRow objects and render as TOC
-                class_rows = [self.summarize_toc(cls) for cls in raw_classes]
+                class_rows = [self.summarize(cls) for cls in raw_classes]
                 _summary_table = self._render_summary_table(class_rows, self.table_style_tocs, include_headers=True)
                 section_name = "Classes"
                 objs = f"{sub_header} {section_name}\n\n{_summary_table}"
@@ -522,7 +522,7 @@ class MdRenderer(Renderer):
             # method summary table ----
             if raw_meths:
                 # Collect SummaryRow objects and render as TOC
-                meth_rows = [self.summarize_toc(meth) for meth in raw_meths]
+                meth_rows = [self.summarize(meth) for meth in raw_meths]
                 _summary_table = self._render_summary_table(meth_rows, self.table_style_tocs, include_headers=True)
                 section_name = (
                     "Methods" if isinstance(el, layout.DocClass) else "Functions"
@@ -823,34 +823,13 @@ class MdRenderer(Renderer):
     def _summary_row(self, link, description):
         return SummaryRow(link=link, description=sanitize(description, allow_markdown=True))
 
-    # Index summarization methods (for main index page) ----------------------
+    # Summarization methods ---------------------------------------------------
 
     @dispatch
     def summarize(self, el):
-        """Produce a summary table for the index."""
+        """Produce a summary table."""
 
         raise NotImplementedError(f"Unsupported type: {type(el)}")
-
-    # TOC summarization methods (for doc page TOCs) --------------------------
-
-    @dispatch
-    def summarize_toc(self, el):
-        """Produce a summary table for TOC sections."""
-
-        raise NotImplementedError(f"Unsupported type: {type(el)}")
-
-    @dispatch
-    def summarize_toc(self, el: layout.Doc):
-        """Summarize a Doc for TOC display."""
-        link = f"[{el.name}](#{el.anchor})"
-        description = self.summarize(el.obj)
-        return self._summary_row(link, description)
-
-    @dispatch
-    def summarize_toc(self, el: layout.Link):
-        """Summarize a Link for TOC display."""
-        description = self.summarize(el.obj)
-        return self._summary_row(f"[](`~{el.name}`)", description)
 
     @dispatch
     def summarize(self, el: layout.Layout):
@@ -919,6 +898,8 @@ class MdRenderer(Renderer):
     def summarize(
         self, el: layout.Doc, path: Optional[str] = None, shorten: bool = False
     ):
+        # When path is None, we're being called directly from render() for TOC
+        # When path is provided, we're being called from Page for index
         if path is None:
             link = f"[{el.name}](#{el.anchor})"
         else:

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -41,6 +41,100 @@
   | z      |                          | The z parameter (unannotated) | _required_ |
   '''
 # ---
+# name: test_render_api_index_with_description_list
+  '''
+  ## API Reference
+  
+  Example API documentation
+  
+  [quartodoc.tests.example.a_func](#quartodoc.tests.example.a_func)
+  
+  :   A function
+  
+  [quartodoc.tests.example_class.C](#quartodoc.tests.example_class.C)
+  
+  :   The short summary.
+  
+  [quartodoc.tests.example.a_attr](#quartodoc.tests.example.a_attr)
+  
+  :   An attribute
+  '''
+# ---
+# name: test_render_class_with_description_list_toc
+  '''
+  # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
+  
+  ```python
+  tests.example_class.C(x, y)
+  ```
+  
+  The short summary.
+  
+  The extended summary,
+  which may be multiple lines.
+  
+  ## Parameters {.doc-section .doc-section-parameters}
+  
+  | Name   | Type   | Description          | Default    |
+  |--------|--------|----------------------|------------|
+  | x      | str    | Uses signature type. | _required_ |
+  | y      | int    | Uses manual type.    | _required_ |
+  
+  ## Attributes
+  
+  [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE)
+  
+  :   An attribute
+  
+  [some_property](#quartodoc.tests.example_class.C.some_property)
+  
+  :   A property
+  
+  [z](#quartodoc.tests.example_class.C.z)
+  
+  :   A documented init attribute
+  
+  ## Classes
+  
+  [D](#quartodoc.tests.example_class.C.D)
+  
+  :   A nested class
+  
+  ### D { #quartodoc.tests.example_class.C.D }
+  
+  ```python
+  tests.example_class.C.D()
+  ```
+  
+  A nested class
+  
+  ## Methods
+  
+  [some_class_method](#quartodoc.tests.example_class.C.some_class_method)
+  
+  :   A class method
+  
+  [some_method](#quartodoc.tests.example_class.C.some_method)
+  
+  :   A method
+  
+  ### some_class_method { #quartodoc.tests.example_class.C.some_class_method }
+  
+  ```python
+  tests.example_class.C.some_class_method()
+  ```
+  
+  A class method
+  
+  ### some_method { #quartodoc.tests.example_class.C.some_method }
+  
+  ```python
+  tests.example_class.C.some_method()
+  ```
+  
+  A method
+  '''
+# ---
 # name: test_render_doc_class[embedded]
   '''
   # quartodoc.tests.example_class.C { #quartodoc.tests.example_class.C }
@@ -365,6 +459,44 @@
   ```
   
   A nested alias target
+  '''
+# ---
+# name: test_render_doc_summarize_toc_table_vs_description_list
+  '''
+  Table
+      | Name | Description |
+      | --- | --- |
+      | [D](#quartodoc.tests.example_class.C.D) | A nested class |
+      | [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE) | An attribute |
+      | [some_class_method](#quartodoc.tests.example_class.C.some_class_method) | A class method |
+      | [some_method](#quartodoc.tests.example_class.C.some_method) | A method |
+      | [some_property](#quartodoc.tests.example_class.C.some_property) | A property |
+      | [z](#quartodoc.tests.example_class.C.z) | A documented init attribute |
+  
+  DescriptionList
+      [D](#quartodoc.tests.example_class.C.D)
+  
+      :   A nested class
+  
+      [SOME_ATTRIBUTE](#quartodoc.tests.example_class.C.SOME_ATTRIBUTE)
+  
+      :   An attribute
+  
+      [some_class_method](#quartodoc.tests.example_class.C.some_class_method)
+  
+      :   A class method
+  
+      [some_method](#quartodoc.tests.example_class.C.some_method)
+  
+      :   A method
+  
+      [some_property](#quartodoc.tests.example_class.C.some_property)
+  
+      :   A property
+  
+      [z](#quartodoc.tests.example_class.C.z)
+  
+      :   A documented init attribute
   '''
 # ---
 # name: test_render_docstring_numpy_linebreaks

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -117,13 +117,13 @@ def test_render_summarize_section_description_list():
 
 
 def test_render_summarize_toc_description_list():
-    """Test summarize_toc with description list style for TOCs."""
+    """Test summarize with description list style for TOCs."""
     renderer = MdRenderer(table_style_tocs="description-list")
     obj = blueprint(layout.Auto(name="a_func", package="quartodoc.tests.example"))
 
-    # Test TOC summarization of a Doc object
+    # Test TOC summarization of a Doc object (path=None indicates TOC context)
     doc = obj  # blueprint returns a Doc object
-    row = renderer.summarize_toc(doc)
+    row = renderer.summarize(doc)
 
     # Check that it returns a SummaryRow
     from quartodoc.renderers.md_renderer import SummaryRow

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -127,6 +127,7 @@ def test_render_summarize_toc_description_list():
 
     # Check that it returns a SummaryRow
     from quartodoc.renderers.md_renderer import SummaryRow
+
     assert isinstance(row, SummaryRow)
     assert row.link == "[a_func](#quartodoc.tests.example.a_func)"
     assert row.description == "A function"
@@ -376,7 +377,7 @@ def test_render_api_index_with_description_list(snapshot):
             blueprint(Auto(name="quartodoc.tests.example.a_func")),
             blueprint(Auto(name="quartodoc.tests.example_class.C")),
             blueprint(Auto(name="quartodoc.tests.example.a_attr")),
-        ]
+        ],
     )
 
     res = renderer.summarize(section)
@@ -398,18 +399,13 @@ def test_render_doc_summarize_toc_table_vs_description_list(snapshot):
 
     # Render using both styles
     res_table = renderer_table._render_summary_table(
-        rows,
-        style_param="table",
-        include_headers=True
+        rows, style_param="table", include_headers=True
     )
 
     res_list = renderer_list._render_summary_table(
         rows,
         style_param="description-list",
-        include_headers=False  # description lists don't use headers
+        include_headers=False,  # description lists don't use headers
     )
 
-    assert snapshot == indented_sections(
-        Table=res_table,
-        DescriptionList=res_list
-    )
+    assert snapshot == indented_sections(Table=res_table, DescriptionList=res_list)

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -100,6 +100,53 @@ def test_render_summarize_section_contents(renderer):
     assert res == f"## abc\n\nzzz\n\n{table}"
 
 
+def test_render_summarize_section_description_list():
+    """Test summarize with description list style for index."""
+    renderer = MdRenderer(table_style_index="description-list")
+    obj = blueprint(layout.Auto(name="a_func", package="quartodoc.tests.example"))
+    section = layout.Section(title="abc", desc="zzz", contents=[obj])
+    res = renderer.summarize(section, is_index=True)
+
+    # Description list format
+    expected = (
+        "## abc\n\nzzz\n\n"
+        "[a_func](#quartodoc.tests.example.a_func)\n\n"
+        ":   A function"
+    )
+    assert res == expected
+
+
+def test_render_summarize_section_toc_description_list():
+    """Test summarize with description list style for TOCs."""
+    renderer = MdRenderer(table_style_tocs="description-list")
+    obj = blueprint(layout.Auto(name="a_func", package="quartodoc.tests.example"))
+    section = layout.Section(title="abc", desc="zzz", contents=[obj])
+    res = renderer.summarize(section, is_index=False)
+
+    # Description list format
+    expected = (
+        "## abc\n\nzzz\n\n"
+        "[a_func](#quartodoc.tests.example.a_func)\n\n"
+        ":   A function"
+    )
+    assert res == expected
+
+
+def test_summary_row():
+    """Test SummaryRow dataclass methods."""
+    from quartodoc.renderers.md_renderer import SummaryRow
+
+    row = SummaryRow(link="[test](test.html)", description="Test description")
+
+    # Test to_tuple
+    assert row.to_tuple() == "| [test](test.html) | Test description |"
+
+    # Test to_definition_list
+    term, definition = row.to_definition_list()
+    assert term == "[test](test.html)"
+    assert definition == "Test description"
+
+
 def test_render_doc_attribute(renderer):
     attr = ds.DocstringAttribute(
         name="abc",

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -105,7 +105,7 @@ def test_render_summarize_section_description_list():
     renderer = MdRenderer(table_style_index="description-list")
     obj = blueprint(layout.Auto(name="a_func", package="quartodoc.tests.example"))
     section = layout.Section(title="abc", desc="zzz", contents=[obj])
-    res = renderer.summarize(section, is_index=True)
+    res = renderer.summarize(section)
 
     # Description list format
     expected = (
@@ -116,20 +116,20 @@ def test_render_summarize_section_description_list():
     assert res == expected
 
 
-def test_render_summarize_section_toc_description_list():
-    """Test summarize with description list style for TOCs."""
+def test_render_summarize_toc_description_list():
+    """Test summarize_toc with description list style for TOCs."""
     renderer = MdRenderer(table_style_tocs="description-list")
     obj = blueprint(layout.Auto(name="a_func", package="quartodoc.tests.example"))
-    section = layout.Section(title="abc", desc="zzz", contents=[obj])
-    res = renderer.summarize(section, is_index=False)
 
-    # Description list format
-    expected = (
-        "## abc\n\nzzz\n\n"
-        "[a_func](#quartodoc.tests.example.a_func)\n\n"
-        ":   A function"
-    )
-    assert res == expected
+    # Test TOC summarization of a Doc object
+    doc = obj  # blueprint returns a Doc object
+    row = renderer.summarize_toc(doc)
+
+    # Check that it returns a SummaryRow
+    from quartodoc.renderers.md_renderer import SummaryRow
+    assert isinstance(row, SummaryRow)
+    assert row.link == "[a_func](#quartodoc.tests.example.a_func)"
+    assert row.description == "A function"
 
 
 def test_summary_row():


### PR DESCRIPTION
Addresses #413 by enabling description list style tables on the index and in the API reference

edit: later, let's clean this up by adding a `summarize_toc()` and `summarize_index()` function. The key is that summarize over a Section is only used in the index, and summarize is evoked over a dc.Object | dc.Alias for the toc table. These functions will signal exactly what is needed where (e.g. can keep summarize over dc.Object and lower, but use the new functions to produce tables where _render_summary_table is currently called)

edit: TODO: document description list features