### PR TITLE
feat: simplify return table and list if possible

### DIFF
--- a/quartodoc/renderers/md_renderer.py
+++ b/quartodoc/renderers/md_renderer.py
@@ -84,16 +84,16 @@ class ParamRow:
 
         part_desc = desc if desc is not None else ""
 
-        anno_sep = Span(":", Attr(classes=["parameter-annotation-sep"]))
+        # Only include the colon separator if there's a name
+        if name is not None:
+            anno_sep = Span(":", Attr(classes=["parameter-annotation-sep"]))
+            parts = [part_name, anno_sep, part_anno, part_default_sep, part_default]
+        else:
+            # No name means no colon separator (e.g., for Raises)
+            parts = [part_anno, part_default_sep, part_default]
 
         # TODO: should code wrap the whole thing like this?
-        param = Code(
-            str(
-                Inlines(
-                    [part_name, anno_sep, part_anno, part_default_sep, part_default]
-                )
-            )
-        ).html
+        param = Code(str(Inlines(parts))).html
         return (param, part_desc)
 
     def to_tuple(self, style: Literal["parameters", "attributes", "returns"]):
@@ -265,7 +265,21 @@ class MdRenderer(Renderer):
         if self.table_style == "description-list":
             return str(DefinitionList([row.to_definition_list() for row in rows]))
         else:
-            row_tuples = [row.to_tuple(style) for row in rows]
+            # Check if any rows have names - if not, omit the Name column
+            # Note: Parameters always have names, but Returns/Raises may not
+            has_names = any(row.name is not None for row in rows)
+
+            if not has_names and style == "returns" and headers[0] == "Name":
+                # Omit Name column when no items have names (e.g., Raises section)
+                headers = headers[1:]  # Remove "Name" from headers
+                row_tuples = [
+                    (row.annotation, sanitize(row.description, allow_markdown=True))
+                    for row in rows
+                ]
+            else:
+                # Standard rendering with all columns
+                row_tuples = [row.to_tuple(style) for row in rows]
+
             table = tabulate(row_tuples, headers=headers, tablefmt="github")
             return table
 
@@ -766,6 +780,7 @@ class MdRenderer(Renderer):
         rows = list(map(self.render, el.value))
         header = ["Name", "Type", "Description"]
 
+        # _render_table will dynamically omit the Name column if no rows have names
         return self._render_table(rows, header, "returns")
 
     @dispatch

--- a/quartodoc/tests/__snapshots__/test_renderers.ambr
+++ b/quartodoc/tests/__snapshots__/test_renderers.ambr
@@ -579,6 +579,184 @@
   | b      | str    | The b parameter. | _required_ |
   '''
 # ---
+# name: test_render_full_numpydoc
+  '''
+  # full_numpydoc_function { #quartodoc.tests.example_docstring_full.full_numpydoc_function }
+  
+  ```python
+  tests.example_docstring_full.full_numpydoc_function(
+      x,
+      y=None,
+      *args,
+      option=False,
+      **kwargs,
+  )
+  ```
+  
+  A one-line summary.
+  
+  An extended summary that provides more detail about what this
+  function does. This demonstrates the full range of numpydoc
+  sections that are supported.
+  
+  ## Parameters {.doc-section .doc-section-parameters}
+  
+  | Name     | Type   | Description                    | Default    |
+  |----------|--------|--------------------------------|------------|
+  | x        | int    | The first parameter.           | _required_ |
+  | y        | str    | The second parameter.          | `None`     |
+  | *args    | float  | Variable positional arguments. | `()`       |
+  | option   | bool   | A keyword-only parameter.      | `False`    |
+  | **kwargs | dict   | Variable keyword arguments.    | `{}`       |
+  
+  ## Returns {.doc-section .doc-section-returns}
+  
+  | Name   | Type   | Description                              |
+  |--------|--------|------------------------------------------|
+  | result | int    | The computed result with name and type.  |
+  |        | list   | A secondary return value with only type. |
+  
+  ## Yields {.doc-section .doc-section-yields}
+  
+  | Name   | Type   | Description              |
+  |--------|--------|--------------------------|
+  | value  | str    | Generated string values. |
+  
+  ## Raises {.doc-section .doc-section-raises}
+  
+  | Type       | Description           |
+  |------------|-----------------------|
+  | ValueError | If x is negative.     |
+  | TypeError  | If y is not a string. |
+  
+  ## See Also {.doc-section .doc-section-see-also}
+  
+  other_function : Related functionality.
+  module.another_function : Another related function.
+  
+  ## Notes {.doc-section .doc-section-notes}
+  
+  I am a note.
+  
+  ## References {.doc-section .doc-section-references}
+  
+  .. [1] Author Name, "Paper Title", Journal, 2024. TODO
+  
+  ## Examples {.doc-section .doc-section-examples}
+  
+  Basic usage:
+  
+  ```python
+  >>> full_numpydoc_function(1, "test")
+  (42, [1, 2, 3])
+  ```
+  
+  With optional parameters:
+  
+  ```python
+  >>> full_numpydoc_function(1, option=True)
+  (42, [])
+  ```
+  '''
+# ---
+# name: test_render_full_numpydoc_description_list
+  '''
+  # full_numpydoc_function { #quartodoc.tests.example_docstring_full.full_numpydoc_function }
+  
+  ```python
+  tests.example_docstring_full.full_numpydoc_function(
+      x,
+      y=None,
+      *args,
+      option=False,
+      **kwargs,
+  )
+  ```
+  
+  A one-line summary.
+  
+  An extended summary that provides more detail about what this
+  function does. This demonstrates the full range of numpydoc
+  sections that are supported.
+  
+  ## Parameters {.doc-section .doc-section-parameters}
+  
+  <code>[**x**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+  
+  :   The first parameter.
+  
+  <code>[**y**]{.parameter-name} [:]{.parameter-annotation-sep} [str]{.parameter-annotation} [ = ]{.parameter-default-sep} [None]{.parameter-default}</code>
+  
+  :   The second parameter.
+  
+  <code>[***args**]{.parameter-name} [:]{.parameter-annotation-sep} [float]{.parameter-annotation} [ = ]{.parameter-default-sep} [()]{.parameter-default}</code>
+  
+  :   Variable positional arguments.
+  
+  <code>[**option**]{.parameter-name} [:]{.parameter-annotation-sep} [bool]{.parameter-annotation} [ = ]{.parameter-default-sep} [False]{.parameter-default}</code>
+  
+  :   A keyword-only parameter.
+  
+  <code>[****kwargs**]{.parameter-name} [:]{.parameter-annotation-sep} [dict]{.parameter-annotation} [ = ]{.parameter-default-sep} [{}]{.parameter-default}</code>
+  
+  :   Variable keyword arguments.
+  
+  ## Returns {.doc-section .doc-section-returns}
+  
+  <code>[**result**]{.parameter-name} [:]{.parameter-annotation-sep} [int]{.parameter-annotation}</code>
+  
+  :   The computed result with name and type.
+  
+  <code>[]{.parameter-name} [:]{.parameter-annotation-sep} [list]{.parameter-annotation}</code>
+  
+  :   A secondary return value with only type.
+  
+  ## Yields {.doc-section .doc-section-yields}
+  
+  <code>[**value**]{.parameter-name} [:]{.parameter-annotation-sep} [str]{.parameter-annotation}</code>
+  
+  :   Generated string values.
+  
+  ## Raises {.doc-section .doc-section-raises}
+  
+  <code>[ValueError]{.parameter-annotation}</code>
+  
+  :   If x is negative.
+  
+  <code>[TypeError]{.parameter-annotation}</code>
+  
+  :   If y is not a string.
+  
+  ## See Also {.doc-section .doc-section-see-also}
+  
+  other_function : Related functionality.
+  module.another_function : Another related function.
+  
+  ## Notes {.doc-section .doc-section-notes}
+  
+  I am a note.
+  
+  ## References {.doc-section .doc-section-references}
+  
+  .. [1] Author Name, "Paper Title", Journal, 2024. TODO
+  
+  ## Examples {.doc-section .doc-section-examples}
+  
+  Basic usage:
+  
+  ```python
+  >>> full_numpydoc_function(1, "test")
+  (42, [1, 2, 3])
+  ```
+  
+  With optional parameters:
+  
+  ```python
+  >>> full_numpydoc_function(1, option=True)
+  (42, [])
+  ```
+  '''
+# ---
 # name: test_render_google_section_yields[int: A description.]
   '''
   Code

--- a/quartodoc/tests/example_docstring_full.py
+++ b/quartodoc/tests/example_docstring_full.py
@@ -1,0 +1,68 @@
+"""Module with comprehensive numpydoc examples."""
+
+
+def full_numpydoc_function(x, y=None, *args, option=False, **kwargs):
+    """A one-line summary.
+
+    An extended summary that provides more detail about what this
+    function does. This demonstrates the full range of numpydoc
+    sections that are supported.
+
+    Parameters
+    ----------
+    x : int
+        The first parameter.
+    y : str, optional
+        The second parameter.
+    *args : float
+        Variable positional arguments.
+    option : bool, default False
+        A keyword-only parameter.
+    **kwargs : dict
+        Variable keyword arguments.
+
+    Returns
+    -------
+    result : int
+        The computed result with name and type.
+    list
+        A secondary return value with only type.
+
+    Yields
+    ------
+    value : str
+        Generated string values.
+
+    Raises
+    ------
+    ValueError
+        If x is negative.
+    TypeError
+        If y is not a string.
+
+    See Also
+    --------
+    other_function : Related functionality.
+    module.another_function : Another related function.
+
+    Notes
+    -----
+    I am a note.
+
+    References
+    ----------
+    .. [1] Author Name, "Paper Title", Journal, 2024. TODO
+
+    Examples
+    --------
+    Basic usage:
+
+    >>> full_numpydoc_function(1, "test")
+    (42, [1, 2, 3])
+
+    With optional parameters:
+
+    >>> full_numpydoc_function(1, option=True)
+    (42, [])
+    """
+    pass

--- a/quartodoc/tests/test_renderers.py
+++ b/quartodoc/tests/test_renderers.py
@@ -409,3 +409,26 @@ def test_render_doc_summarize_toc_table_vs_description_list(snapshot):
     )
 
     assert snapshot == indented_sections(Table=res_table, DescriptionList=res_list)
+
+
+def test_render_full_numpydoc(snapshot, renderer):
+    """Test rendering a function with comprehensive numpydoc sections."""
+    package = "quartodoc.tests.example_docstring_full"
+    auto = Auto(name="full_numpydoc_function", package=package)
+    bp = blueprint(auto, parser="numpy")
+
+    res = renderer.render(bp)
+
+    assert res == snapshot
+
+
+def test_render_full_numpydoc_description_list(snapshot):
+    """Test rendering a function with comprehensive numpydoc sections using description list style."""
+    renderer = MdRenderer(table_style="description-list")
+    package = "quartodoc.tests.example_docstring_full"
+    auto = Auto(name="full_numpydoc_function", package=package)
+    bp = blueprint(auto, parser="numpy")
+
+    res = renderer.render(bp)
+
+    assert res == snapshot


### PR DESCRIPTION
Addresses #389 and #390 by simplifying table output for Returns, Raises, and Yields if their results are not given a name. E.g. the example below would

**produces a table with type and description**

```
"""
...

Raises
------
LinAlgException
    If the matrix is not numerically invertible.
"""
```

**produces a table with name, type, and description**

```
"""
...

Raises
------
some_err: LinAlgException
    If the matrix is not numerically invertible.
"""
```