### PR TITLE
Autopopulate API contents if none provided

### DIFF
--- a/docs/get-started/overview.qmd
+++ b/docs/get-started/overview.qmd
@@ -161,6 +161,8 @@ quartodoc:
 
 The functions listed in `contents` are assumed to be imported from the package.
 
+If no contents are provided, quartodoc will attempt to pull in all modules (i.e. `.py` files) from the package.
+
 
 ## Learning more
 

--- a/quartodoc/_pydantic_compat.py
+++ b/quartodoc/_pydantic_compat.py
@@ -5,6 +5,7 @@ try:
         Extra,
         PrivateAttr,
         ValidationError,
+        validator,
     )  # noqa
 except ImportError:
-    from pydantic import BaseModel, Field, Extra, PrivateAttr, ValidationError  # noqa
+    from pydantic import BaseModel, Field, Extra, PrivateAttr, ValidationError, validator  # noqa

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -295,7 +295,9 @@ class BlueprintTransformer(PydanticTransformer):
     @dispatch
     def enter(self, el: Section):
         if el.contents:
-            return el
+            # Already have contents: still recurse so child Auto entries get
+            # transformed into Doc elements (don't short-circuit the visitor).
+            return super().enter(el)
 
         package = self.crnt_package
         label = el.title or el.subtitle or "(untitled)"

--- a/quartodoc/builder/blueprint.py
+++ b/quartodoc/builder/blueprint.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import importlib.util
 import logging
 import json
 import yaml
+
+from collections import OrderedDict
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
 
 from .._griffe_compat import dataclasses as dc
 from .._griffe_compat import (
@@ -42,6 +47,47 @@ _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from quartodoc._pydantic_compat import BaseModel
+
+
+def _identify_files_to_document(
+    path: Path,
+    file_patterns: List[str],
+    ignore: Optional[Iterable[str]] = None,
+) -> Set[Path]:
+    reversed_patterns = file_patterns.copy()
+    reversed_patterns.reverse()
+
+    files_to_document: dict = OrderedDict()
+    for pattern in reversed_patterns:
+        for file in path.rglob(pattern=pattern):
+            files_to_document[file.with_suffix("")] = file
+    result = set(files_to_document.values())
+
+    if ignore:
+        for pattern in ignore:
+            result = result.difference(set(path.glob(pattern=pattern)))
+
+    return {p.resolve() for p in result}
+
+
+def _auto_contents_from_package(package_name: str) -> list[Auto]:
+    """Return Auto entries for every .py file in *package_name*, excluding __init__ files."""
+    spec = importlib.util.find_spec(package_name)
+    if spec is None or not spec.submodule_search_locations:
+        return []
+
+    pkg_path = Path(list(spec.submodule_search_locations)[0])
+    files = _identify_files_to_document(
+        pkg_path,
+        file_patterns=["*.py"],
+        ignore=["**/__init__.py", "**/__pycache__/**"],
+    )
+
+    contents = []
+    for file in sorted(files):
+        parts = list(file.relative_to(pkg_path).with_suffix("").parts)
+        contents.append(Auto(name=".".join(parts)))
+    return contents
 
 
 def _auto_package(mod: dc.Module) -> list[Section]:
@@ -245,6 +291,34 @@ class BlueprintTransformer(PydanticTransformer):
             return super().enter(new_el)
 
         return super().enter(el)
+
+    @dispatch
+    def enter(self, el: Section):
+        if el.contents:
+            return el
+
+        package = self.crnt_package
+        label = el.title or el.subtitle or "(untitled)"
+
+        if not package:
+            _log.warning(
+                f"Section '{label}' has no contents and no package is configured."
+                " Cannot auto-populate contents."
+            )
+            return el
+
+        _log.warning(
+            f"Section '{label}' has no contents. Auto-populating from package '{package}'."
+        )
+
+        contents = _auto_contents_from_package(package)
+        if not contents:
+            _log.warning(f"No Python files found in package '{package}'.")
+            return el
+
+        new = el.copy()
+        new.contents = contents
+        return super().enter(new)
 
     @dispatch
     def exit(self, el: Section):

--- a/quartodoc/layout.py
+++ b/quartodoc/layout.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing_extensions import Annotated
 from typing import Literal, Union, Optional
 
-from ._pydantic_compat import BaseModel, Field, Extra, PrivateAttr
+from ._pydantic_compat import BaseModel, Field, Extra, PrivateAttr, validator
 
 
 _log = logging.getLogger(__name__)
@@ -123,6 +123,12 @@ class Page(_Structural):
     flatten: bool = False
 
     contents: ContentList
+
+    @validator("contents")
+    def _contents_not_empty(cls, v):
+        if not v:
+            raise ValueError("Page contents must not be empty.")
+        return v
 
     @property
     def obj(self):


### PR DESCRIPTION
## Summary

For small Python packages, you typically want to document the entire API, and don't need to do any customization in terms of ordering. But currently, `quartodoc` requires the API contents to be explicitly listed in `_quarto.yml`.

This PR makes it so if no `contents` are provided to `quartodoc`, it will behave as if every source file was listed.

This behavior was copied from [mkdocstrings-python](https://mkdocstrings.github.io/python/usage/#finding-modules), since this was the only feature I could find that `mkdocstrings` had that `quartodoc` seemed to lack :)

## Details

- Auto-populate a section's `contents` from the configured package when none is provided, so users can omit explicit content lists for full-package documentation.
- Walks the package's submodule search locations for `*.py` files (excluding `__init__.py` and `__pycache__`) and generates an `Auto` entry per module.
- Adds a `validator` on `Page.contents` to reject empty page contents, and re-exports `validator` from the pydantic v1/v2 compatibility shim.
- Documents the new behavior in `docs/get-started/overview.qmd`.

## Test plan

- [ ] Build a site with a `quartodoc` config whose section omits `contents` and confirm modules are auto-discovered.
- [ ] Build a site with explicit `contents` and confirm behavior is unchanged.
- [ ] Confirm a warning is logged when a section has no contents and no package is configured.
- [ ] Confirm a `Page` with empty `contents` raises a validation error.
- [ ] Verify the new docs section renders correctly in `docs/get-started/overview.qmd`.

(NB: feature implemented with the help of Claude)